### PR TITLE
ImplementationGuide Artifact Packaging Operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,8 @@ hs_err_pid*
 
 /src/main/resources/org/opencds/cqf/jsonschema/output/*
 !/src/main/resources/org/opencds/cqf/jsonschema/output/.gitkeep
+
+/src/main/resources/org/opencds/cqf/igtools/output/*
+!/src/main/resources/org/opencds/cqf/igtools/output/.gitkeep
+
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-dstu3</artifactId>
-            <version>3.4.0</version>
+            <version>3.7.0</version>
         </dependency>
 
         <!-- Useful String ops -->
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-to-elm</artifactId>
-            <version>1.2.20</version>
+            <version>1.3.16-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/opencds/cqf/OperationFactory.java
+++ b/src/main/java/org/opencds/cqf/OperationFactory.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf;
 
 //import org.opencds.cqf.jsonschema.SchemaGenerator;
+import org.opencds.cqf.igtools.IgBundler;
 import org.opencds.cqf.library.LibraryGenerator;
 import org.opencds.cqf.qdm.QdmToQiCore;
 import org.opencds.cqf.quick.QuickPageGenerator;
@@ -24,6 +25,8 @@ class OperationFactory {
                 return new LibraryGenerator();
             case "JsonSchemaGenerator":
 //                return new SchemaGenerator();
+            case "BundleIg":
+                return new IgBundler();
             case "CqlToMeasure":
                 throw new NotImplementedException();
             case "BundlesToBundle":

--- a/src/main/java/org/opencds/cqf/igtools/IgBundler.java
+++ b/src/main/java/org/opencds/cqf/igtools/IgBundler.java
@@ -227,7 +227,7 @@ public class IgBundler extends Operation
             {
                 resource = xmlParser.parseResource(new FileReader(new File(path.toString())));
             }
-            else if (path.endsWith(".json"))
+            else if (path.toString().endsWith(".json"))
             {
                 resource = jsonParser.parseResource(new FileReader(new File(path.toString())));
             }

--- a/src/main/java/org/opencds/cqf/igtools/IgBundler.java
+++ b/src/main/java/org/opencds/cqf/igtools/IgBundler.java
@@ -1,0 +1,278 @@
+package org.opencds.cqf.igtools;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.Operation;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ *
+ * The purpose of this operation is to package the examples and artifacts, contained within an IG, into transaction bundles
+ * and write to specified output directory.
+ *
+ * Operation can be called with following 3 args:
+ *  -outputpath (-op) Path to directory where Bundles will be written (optional)
+ *  -pathtoig (-ptig) Path to ImplementationGuide project root (where ig.json is stored) (required)
+ *  -encoding (-e) Preferred encoding. XML and JSON are supported (JSON by default) (optional)
+ *
+ * */
+public class IgBundler extends Operation
+{
+    private String pathToIg; // -pathtoig | -ptig
+    private String encoding = "json"; // -encoding (-e)
+
+    private FhirContext fhirContext; // determined during ig.json processing
+    private IParser jsonParser;
+    private IParser xmlParser;
+
+    private Gson gson = new Gson();
+
+    private List<String> resourcePaths = new ArrayList<>();
+    private List<String> resourceFiles = new ArrayList<>();
+
+    private Map<String, IBaseResource> outputBundles = new HashMap<>();
+
+    @Override
+    public void execute(String[] args)
+    {
+        setOutputPath("src/main/resources/org/opencds/cqf/igtools/output"); // default
+
+        for (String arg : args) {
+            if (arg.equals("-BundleIg")) continue;
+            String[] flagAndValue = arg.split("=");
+            if (flagAndValue.length < 2) {
+                throw new IllegalArgumentException("Invalid argument: " + arg);
+            }
+            String flag = flagAndValue[0];
+            String value = flagAndValue[1];
+
+            switch (flag.replace("-", "").toLowerCase()) {
+                case "outputpath": case "op": setOutputPath(value); break; // -outputpath (-op)
+                case "pathtoig": case "ptig": pathToIg = value; break;
+                case "encoding": case "e": encoding = value.toLowerCase(); break;
+                default: throw new IllegalArgumentException("Unknown flag: " + flag);
+            }
+        }
+
+        if (pathToIg == null) {
+            throw new IllegalArgumentException("The path to the IG is required");
+        }
+
+        JsonObject igControl = getIgControl();
+        setFhirContext(igControl);
+        jsonParser = fhirContext.newJsonParser();
+        xmlParser = fhirContext.newXmlParser();
+        setResourcePaths(igControl);
+        setResourceFiles(igControl);
+        resolveDirectoryFiles();
+        outputBundles();
+    }
+
+    /***
+     * Parse the ig.json configuration file.
+     * @return JsonObject representation of the ig.json
+     */
+    private JsonObject getIgControl()
+    {
+        try
+        {
+            return gson.fromJson(new FileReader(new File(pathToIg + "/ig.json")), JsonObject.class);
+        }
+        catch (FileNotFoundException e)
+        {
+            e.printStackTrace();
+            throw new RuntimeException("Error reading control file: " + e.getMessage());
+        }
+    }
+
+    /***
+     * Determine the FHIR version from the ig.json configuration.
+     * @param igControl JsonObject representation of the ig.json
+     */
+    private void setFhirContext(JsonObject igControl)
+    {
+        if (igControl.has("version") && igControl.get("version").isJsonPrimitive())
+        {
+            String version = igControl.get("version").getAsString();
+            if (version.equals("3.0.0") || version.equals("3.0.1"))
+            {
+                fhirContext = FhirContext.forDstu3();
+            }
+            else
+            {
+                throw new UnsupportedOperationException("The BundleIg operation currently only supports FHIR STU3");
+            }
+        }
+        else
+        {
+            throw new RuntimeException("Version is required to be populated in the ig.json");
+        }
+    }
+
+    /***
+     * Determine the paths to directories containing resources defined by the IG.
+     * @param igControl JsonObject representation of the ig.json
+     */
+    private void setResourcePaths(JsonObject igControl)
+    {
+        if (igControl.has("paths") && igControl.get("paths").isJsonObject())
+        {
+            JsonObject paths = igControl.get("paths").getAsJsonObject();
+            if (paths.has("resources"))
+            {
+                JsonElement resources = paths.get("resources");
+                if (resources.isJsonArray())
+                {
+                    for (JsonElement path : resources.getAsJsonArray())
+                    {
+                        if (path.isJsonPrimitive())
+                        {
+                            resourcePaths.add(pathToIg + "/" + path.getAsString());
+                            outputBundles.put(path.getAsString(), null);
+                        }
+                    }
+                }
+                else
+                {
+                    resourcePaths.add(pathToIg + "/" + resources.getAsString());
+                }
+            }
+        }
+    }
+
+    /***
+     * Determine the ig resources file names specified in the ig.json.
+     * @param igControl JsonObject representation of the ig.json
+     */
+    private void setResourceFiles(JsonObject igControl)
+    {
+        if (igControl.has("resources") && igControl.get("resources").isJsonObject())
+        {
+            for (Map.Entry<String, JsonElement> resources : igControl.get("resources").getAsJsonObject().entrySet())
+            {
+                if (resources.getKey().startsWith("Bundle") || resources.getKey().startsWith("StructureDefinition"))
+                {
+                    continue;
+                }
+                if (resources.getValue().isJsonObject()
+                        && resources.getValue().getAsJsonObject().has("source")
+                        && resources.getValue().getAsJsonObject().get("source").isJsonPrimitive())
+                {
+                    resourceFiles.add(resources.getValue().getAsJsonObject().get("source").getAsString());
+                }
+            }
+        }
+    }
+
+    /***
+     * Retrieve the resource files and build Bundle(s)
+     */
+    private void resolveDirectoryFiles()
+    {
+        for (String path : resourcePaths)
+        {
+            // Assuming STU3... TODO: will need to extend this logic to handle different FHIR versions
+            Bundle bundle = new Bundle();
+            bundle.setType(Bundle.BundleType.TRANSACTION);
+
+            try (Stream<Path> paths = Files.walk(Paths.get(path)))
+            {
+                paths
+                        .filter(Files::isRegularFile)
+                        .filter(x -> resourceFiles.contains(x.getFileName().toString()))
+                        .forEach(x -> addArtifactToBundle(x, bundle));
+            }
+            catch (IOException ioe)
+            {
+                throw new RuntimeException(ioe.getMessage());
+            }
+
+            for (Map.Entry<String, IBaseResource> entry : outputBundles.entrySet())
+            {
+                if (path.endsWith(entry.getKey()) && entry.getValue() == null)
+                {
+                    outputBundles.put(entry.getKey(), bundle);
+                    break;
+                }
+            }
+        }
+    }
+
+    /***
+     * Parse artifact file and add to Bundle. NOTE: this method assumes FHIR STU3 artifacts are being used.
+     * @param path Path to artifact
+     * @param bundle Bundle to populate
+     */
+    private void addArtifactToBundle(Path path, Bundle bundle)
+    {
+        IBaseResource resource;
+        try
+        {
+            if (path.toString().endsWith(".xml"))
+            {
+                resource = xmlParser.parseResource(new FileReader(new File(path.toString())));
+            }
+            else if (path.endsWith(".json"))
+            {
+                resource = jsonParser.parseResource(new FileReader(new File(path.toString())));
+            }
+            else
+            {
+                throw new RuntimeException("Unknown file type: " + path.toString());
+            }
+        }
+        catch (FileNotFoundException fnfe)
+        {
+            throw new RuntimeException("Error reading file: " + path.toString());
+        }
+
+        bundle.addEntry(
+                new Bundle.BundleEntryComponent()
+                        .setResource((Resource) resource)
+                        .setRequest(
+                                new Bundle.BundleEntryRequestComponent()
+                                        .setMethod(Bundle.HTTPVerb.PUT)
+                                        .setUrl(((Resource) resource).getId())
+                        )
+        );
+    }
+
+    /***
+     * Write Bundles to output directory.
+     */
+    private void outputBundles()
+    {
+        for (Map.Entry<String, IBaseResource> set : outputBundles.entrySet())
+        {
+            try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + set.getKey() + "." + encoding))
+            {
+                writer.write(
+                        encoding.equals("json")
+                                ? jsonParser.setPrettyPrint(true).encodeResourceToString(set.getValue()).getBytes()
+                                : xmlParser.setPrettyPrint(true).encodeResourceToString(set.getValue()).getBytes()
+                );
+                writer.flush();
+            }
+            catch (IOException e)
+            {
+                e.printStackTrace();
+                throw new RuntimeException("Error writing Bundle to file: " + e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added new operation that packages all artifacts contained within an IG (specified in the ig.json) as transaction bundles. This operation should greatly ease the workflow around loading IG artifacts into a FHIR server for testing and improve share-ability.