### PR TITLE
Library refresh bug fixes

### DIFF
--- a/src/main/java/org/opencds/cqf/igtools/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/igtools/IGProcessor.java
@@ -288,17 +288,17 @@ public class IGProcessor {
                 String cqlLibrarySourcePath = (cqlLibrarySourcePaths.isEmpty()) ? null : cqlLibrarySourcePaths.get(0);
                 if (includeTerminology) {
                     shouldPersist = shouldPersist
-                            & bundleValueSets(cqlLibrarySourcePath, igPath, fhirContext, resources, encoding, includeDependencies, includeVersion);
+                        & bundleValueSets(cqlLibrarySourcePath, igPath, fhirContext, resources, encoding, includeDependencies, includeVersion);
                 }
 
                 if (includeDependencies) {
                     shouldPersist = shouldPersist
-                            & bundleDependencies(librarySourcePath, fhirContext, resources, encoding);
+                        & bundleDependencies(librarySourcePath, fhirContext, resources, encoding);
                 }
 
                 if (includePatientScenarios) {
                     shouldPersist = shouldPersist
-                            & bundleTestCases(igPath, refreshedLibraryName, fhirContext, resources);
+                        & bundleTestCases(igPath, refreshedLibraryName, fhirContext, resources);
                 }
 
                 if (shouldPersist) {
@@ -509,8 +509,14 @@ public class IGProcessor {
         Boolean shouldPersist = true;
         try {
             Map<String, IAnyResource> dependencies = ResourceUtils.getDepLibraryResources(path, fhirContext, encoding);
+
+            String currentResourceID = FilenameUtils.getBaseName(path);
             for (IAnyResource resource : dependencies.values()) {
                 resources.putIfAbsent(resource.getId(), resource);
+
+                // NOTE: Assuming dependency library will be in directory of dependent.
+                String dependencyPath = path.replace(currentResourceID, FilenameUtils.getBaseName(resource.getId()));
+                bundleDependencies(dependencyPath, fhirContext, resources, encoding);
             }
         } catch (Exception e) {
             shouldPersist = false;
@@ -596,6 +602,8 @@ public class IGProcessor {
         
         if (includeDependencies) {
             Map<String, IAnyResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding);
+
+            //TODO: Needs to be recursive
             if (!depLibraries.isEmpty()) {
                 String depLibrariesID = "library-deps-" + libraryName;
                 Object bundle = BundleUtils.bundleArtifacts(depLibrariesID, new ArrayList<IAnyResource>(depLibraries.values()), fhirContext);            

--- a/src/main/java/org/opencds/cqf/igtools/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/igtools/IGProcessor.java
@@ -1,11 +1,6 @@
 package org.opencds.cqf.igtools;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -139,7 +134,6 @@ public class IGProcessor {
 
         for (String path : cqlContentPaths) {
             try {
-                //ask about how to do this better
                 String libraryPath = IOUtils.getLibraryPathAssociatedWithCqlFileName(path, fhirContext);               
                 
                 STU3LibraryProcessor.refreshLibraryContent(path, libraryPath, fhirContext, outputEncoding, versioned);
@@ -163,7 +157,6 @@ public class IGProcessor {
 
         for (String path : cqlContentPaths) {
             try {
-                //ask about how to do this better
                 String libraryPath = IOUtils.getLibraryPathAssociatedWithCqlFileName(path, fhirContext);
                 
                 R4LibraryProcessor.refreshLibraryContent(path, libraryPath, fhirContext, outputEncoding, versioned);
@@ -238,10 +231,8 @@ public class IGProcessor {
     private static void bundleMeasures(ArrayList<String> refreshedLibraryNames, String igPath, Boolean includeDependencies,
             Boolean includeTerminology, Boolean includePatientScenarios, Boolean includeVersion, FhirContext fhirContext, String fhirUri,
             Encoding encoding) {
-        // The set to bundle should be the union of the successfully refreshed Measures
-        // and Libraries
-        // Until we have the ability to refresh Measures, the set is the union of
-        // existing Measures and successfully refreshed Libraries
+        // The set to bundle should be the union of the successfully refreshed Measures and Libraries
+        // Until we have the ability to refresh Measures, the set is the union of existing Measures and successfully refreshed Libraries
         System.out.println("Bundling measures...");
         HashSet<String> measureSourcePaths = IOUtils.getMeasurePaths(fhirContext);
         List<String> measurePathLibraryNames = new ArrayList<String>();
@@ -261,14 +252,12 @@ public class IGProcessor {
                 Map<String, IAnyResource> resources = new HashMap<String, IAnyResource>();
 
                 String refreshedLibraryFileName = IOUtils.formatFileName(refreshedLibraryName, encoding, fhirContext);
-                String librarySourcePath;
-                try {
-                    librarySourcePath = IOUtils.getLibraryPathAssociatedWithCqlFileName(refreshedLibraryFileName, fhirContext);
-                } catch (Exception e) {
-                    LogUtils.putException(refreshedLibraryName, e);
+                String librarySourcePath = IOUtils.getLibraryPathAssociatedWithCqlFileName(refreshedLibraryFileName, fhirContext);
+                if (librarySourcePath == null) {
+                    LogUtils.putException(refreshedLibraryName, new FileNotFoundException("Could not find a Library Resource Associated with: " + refreshedLibraryFileName));
                     continue;
-                } 
-                
+                }
+
                 String measureSourcePath = "";
                 for (String path : measureSourcePaths) {
                     if (path.endsWith(refreshedLibraryFileName))
@@ -360,13 +349,11 @@ public class IGProcessor {
                 Map<String, IAnyResource> resources = new HashMap<String, IAnyResource>();
 
                 String refreshedLibraryFileName = IOUtils.formatFileName(refreshedLibraryName, encoding, fhirContext);
-                String librarySourcePath;
-                try {
-                    librarySourcePath = IOUtils.getLibraryPathAssociatedWithCqlFileName(refreshedLibraryFileName, fhirContext);
-                } catch (Exception e) {
-                    LogUtils.putException(refreshedLibraryName, e);
+                String librarySourcePath = IOUtils.getLibraryPathAssociatedWithCqlFileName(refreshedLibraryFileName, fhirContext);
+                if (librarySourcePath == null) {
+                    LogUtils.putException(refreshedLibraryName, new FileNotFoundException("Could not find a Library Resource Associated with: " + refreshedLibraryFileName));
                     continue;
-                } 
+                }
                                 
                 String planDefinitionSourcePath = "";
                 for (String path : planDefinitionSourcePaths) {

--- a/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
@@ -54,8 +54,7 @@ public class R4LibraryProcessor {
                 .forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
 
         referenceLibrary.getContent().clear();
-        generatedLibrary.getContent().stream()
-                .forEach(getContent -> attachContent(referenceLibrary, translator, IOUtils.getCqlString(cqlContentPath)));
+        attachContent(referenceLibrary, translator, IOUtils.getCqlString(cqlContentPath));
 
         BaseNarrativeProvider<Narrative> narrativeProvider = new org.opencds.cqf.library.r4.NarrativeProvider();
         INarrative narrative = narrativeProvider.getNarrative(fhirContext, generatedLibrary);

--- a/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
@@ -40,7 +40,7 @@ public class R4LibraryProcessor {
     private static void refreshLibrary(Library referenceLibrary, String cqlContentPath, String outputPath, Encoding encoding, Boolean includeVersion, CqlTranslator translator, FhirContext fhirContext) {
         Library generatedLibrary = processLibrary(cqlContentPath, translator, includeVersion, fhirContext);
         mergeDiff(referenceLibrary, generatedLibrary, cqlContentPath, translator, fhirContext);
-        IOUtils.writeResource(generatedLibrary, outputPath, encoding, fhirContext);
+        IOUtils.writeResource(referenceLibrary, outputPath, encoding, fhirContext);
     }
 
     private static void mergeDiff(Library referenceLibrary, Library generatedLibrary, String cqlContentPath, CqlTranslator translator,
@@ -98,7 +98,7 @@ public class R4LibraryProcessor {
         library.setVersion(version);
         library.setStatus(Enumerations.PublicationStatus.ACTIVE);
         library.setExperimental(true);
-        library.setType(new CodeableConcept().addCoding(new Coding().setCode("logic-library").setSystem("http://hl7.org/fhir/codesystem-library-type.html")));
+        library.setType(new CodeableConcept().addCoding(new Coding().setCode("logic-library").setSystem("http://terminology.hl7.org/CodeSystem/library-type")));
         return library;
     }
 

--- a/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
@@ -24,10 +24,14 @@ public class R4LibraryProcessor {
     private static CqfmSoftwareSystemHelper cqfmHelper = new CqfmSoftwareSystemHelper();
 
     public static Boolean refreshLibraryContent(String cqlContentPath, String libraryPath, FhirContext fhirContext, Encoding encoding, Boolean includeVersion) {
-        Library resource = (Library)IOUtils.readResource(libraryPath, fhirContext, true);
-        Boolean libraryExists = resource != null;       
-
         CqlTranslator translator = getTranslator(cqlContentPath);
+
+        Boolean libraryExists = false;
+        Library resource = null;
+        if (libraryPath != null) {
+            resource = (Library) IOUtils.readResource(libraryPath, fhirContext, true);
+            libraryExists = resource != null;
+        }
               
         if (libraryExists) {            
             refreshLibrary(resource, cqlContentPath, IOUtils.getParentDirectoryPath(libraryPath), encoding, includeVersion, translator, fhirContext);

--- a/src/main/java/org/opencds/cqf/library/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/STU3LibraryProcessor.java
@@ -25,12 +25,16 @@ import org.hl7.fhir.dstu3.model.*;
 public class STU3LibraryProcessor {
     private static CqfmSoftwareSystemHelper cqfmHelper = new CqfmSoftwareSystemHelper();
 
-    public static Boolean refreshLibraryContent(String cqlContentPath, String libraryPath, FhirContext fhirContext, Encoding encoding, Boolean includeVersion) {         
-        Library resource = (Library)IOUtils.readResource(libraryPath, fhirContext, true);
-        Boolean libraryExists = resource != null;       
-
+    public static Boolean refreshLibraryContent(String cqlContentPath, String libraryPath, FhirContext fhirContext, Encoding encoding, Boolean includeVersion) {
         CqlTranslator translator = getTranslator(cqlContentPath);
-              
+
+        Boolean libraryExists = false;
+        Library resource = null;
+        if (libraryPath != null) {
+            resource = (Library)IOUtils.readResource(libraryPath, fhirContext, true);
+            libraryExists = resource != null;
+        }
+
         if (libraryExists) {            
             refreshLibrary(resource, cqlContentPath, IOUtils.getParentDirectoryPath(libraryPath), encoding, includeVersion, translator, fhirContext);
         } else {

--- a/src/main/java/org/opencds/cqf/library/stu3/LibraryGenerator.java
+++ b/src/main/java/org/opencds/cqf/library/stu3/LibraryGenerator.java
@@ -29,7 +29,7 @@ public class LibraryGenerator extends BaseLibraryGenerator<Library, NarrativePro
         org.hl7.elm.r1.Library elm = translator.toELM();
         Library library = loadIfExists();
         if (library == null) {
-            library = createLibrary(nameToId(elm.getIdentifier().getId()),
+            library = createLibrary(nameToId(elm.getIdentifier().getId(), elm.getIdentifier().getVersion()),
                     elm.getIdentifier().getId(), elm.getIdentifier().getVersion());
         }
         if (elm.getIncludes() != null && !elm.getIncludes().getDef().isEmpty()) {
@@ -118,15 +118,16 @@ public class LibraryGenerator extends BaseLibraryGenerator<Library, NarrativePro
     private String getIncludedLibraryId(IncludeDef def) {
         String name = getIncludedLibraryName(def);
         String version = def.getVersion();
-        return nameToId(name);
+        return nameToId(name, version);
     }
 
     private String getIncludedLibraryName(IncludeDef def) {
         return def.getPath();
     }
 
-    private String nameToId(String name) {
-        return name.replaceAll("_", "-").toLowerCase();
+    private String nameToId(String name, String version) {
+        String nameAndVersion = "library-" + name + "-" + version;
+        return nameAndVersion.replaceAll("_", "-");
     }
 
     private String createFileName(String id, String encoding) {

--- a/src/main/java/org/opencds/cqf/library/stu3/LibraryGenerator.java
+++ b/src/main/java/org/opencds/cqf/library/stu3/LibraryGenerator.java
@@ -29,7 +29,7 @@ public class LibraryGenerator extends BaseLibraryGenerator<Library, NarrativePro
         org.hl7.elm.r1.Library elm = translator.toELM();
         Library library = loadIfExists();
         if (library == null) {
-            library = createLibrary(nameToId(elm.getIdentifier().getId(), elm.getIdentifier().getVersion()),
+            library = createLibrary(nameToId(elm.getIdentifier().getId()),
                     elm.getIdentifier().getId(), elm.getIdentifier().getVersion());
         }
         if (elm.getIncludes() != null && !elm.getIncludes().getDef().isEmpty()) {
@@ -118,7 +118,7 @@ public class LibraryGenerator extends BaseLibraryGenerator<Library, NarrativePro
     private String getIncludedLibraryId(IncludeDef def) {
         String name = getIncludedLibraryName(def);
         String version = def.getVersion();
-        return nameToId(name, version);
+        return nameToId(name);
     }
 
     private String getIncludedLibraryName(IncludeDef def) {
@@ -127,11 +127,6 @@ public class LibraryGenerator extends BaseLibraryGenerator<Library, NarrativePro
 
     private String nameToId(String name) {
         return name.replaceAll("_", "-").toLowerCase();
-    }
-
-    private String nameToId(String name, String version) {
-        String nameAndVersion = "library-" + name + "-" + version;
-        return nameAndVersion.replaceAll("_", "-");
     }
 
     private String createFileName(String id, String encoding) {

--- a/src/main/java/org/opencds/cqf/library/stu3/LibraryRefresher.java
+++ b/src/main/java/org/opencds/cqf/library/stu3/LibraryRefresher.java
@@ -61,8 +61,7 @@ public class LibraryRefresher extends BaseLibraryGenerator<Library, NarrativePro
         .forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
 
         referenceLibrary.getContent().clear();
-        generatedLibrary.getContent().stream()
-        .forEach(getContent -> attachContent(referenceLibrary, generatedLibraryTranslator, getCqlMap().get(id)));
+        attachContent(referenceLibrary, generatedLibraryTranslator, getCqlMap().get(id));
 
         referenceLibrary.setText(getNarrativeProvider().getNarrative(getFhirContext(), generatedLibrary));
 
@@ -78,7 +77,7 @@ public class LibraryRefresher extends BaseLibraryGenerator<Library, NarrativePro
     // Populate metadata
     private Library populateMeta(String name, String version) {
         Library library = new Library();
-        library.setId(nameToId(name));
+        library.setId(nameToId(name, version));
         library.setName(name);
         library.setVersion(version);
         library.setStatus(Enumerations.PublicationStatus.ACTIVE);
@@ -131,15 +130,17 @@ public class LibraryRefresher extends BaseLibraryGenerator<Library, NarrativePro
     //helpers
     private String getIncludedLibraryId(IncludeDef def) {
         String name = getIncludedLibraryName(def);
-        return nameToId(name);
+        String version = def.getVersion();
+        return nameToId(name, version);
     }
 
     private String getIncludedLibraryName(IncludeDef def) {
         return def.getPath();
     }
 
-    private String nameToId(String name) {
-        return name.replaceAll("_", "-").toLowerCase();
+    private String nameToId(String name, String version) {
+        String nameAndVersion = "library-" + name + "-" + version;
+        return nameAndVersion.replaceAll("_", "-");
     }
 
     private String createFileName(String id, String encoding) {

--- a/src/main/java/org/opencds/cqf/library/stu3/LibraryRefresher.java
+++ b/src/main/java/org/opencds/cqf/library/stu3/LibraryRefresher.java
@@ -78,12 +78,12 @@ public class LibraryRefresher extends BaseLibraryGenerator<Library, NarrativePro
     // Populate metadata
     private Library populateMeta(String name, String version) {
         Library library = new Library();
-        library.setId(nameToId(name, version));
+        library.setId(nameToId(name));
         library.setName(name);
         library.setVersion(version);
         library.setStatus(Enumerations.PublicationStatus.ACTIVE);
         library.setExperimental(true);
-        library.setType(new CodeableConcept().addCoding(new Coding().setCode("logic-library").setSystem("http://hl7.org/fhir/codesystem-library-type.html")));
+        library.setType(new CodeableConcept().addCoding(new Coding().setCode("logic-library").setSystem("http://terminology.hl7.org/CodeSystem/library-type")));
         return library;
     }
 
@@ -118,21 +118,20 @@ public class LibraryRefresher extends BaseLibraryGenerator<Library, NarrativePro
     // Base64 encode content
     private void attachContent(Library library, CqlTranslator translator, String cql) {
         library.addContent(
-                new Attachment()
-                        .setContentType("application/elm+xml")
-                        .setData(translator.toXml().getBytes())
+            new Attachment()
+                .setContentType("application/elm+xml")
+                .setData(translator.toXml().getBytes())
         ).addContent(
-                new Attachment()
-                        .setContentType("text/cql")
-                        .setData(cql.getBytes())
+            new Attachment()
+                .setContentType("text/cql")
+                .setData(cql.getBytes())
         );
     }
 
     //helpers
     private String getIncludedLibraryId(IncludeDef def) {
         String name = getIncludedLibraryName(def);
-        String version = def.getVersion();
-        return nameToId(name, version);
+        return nameToId(name);
     }
 
     private String getIncludedLibraryName(IncludeDef def) {
@@ -141,11 +140,6 @@ public class LibraryRefresher extends BaseLibraryGenerator<Library, NarrativePro
 
     private String nameToId(String name) {
         return name.replaceAll("_", "-").toLowerCase();
-    }
-
-    private String nameToId(String name, String version) {
-        String nameAndVersion = "library-" + name + "-" + version;
-        return nameAndVersion.replaceAll("_", "-");
     }
 
     private String createFileName(String id, String encoding) {

--- a/src/main/java/org/opencds/cqf/utilities/IOUtils.java
+++ b/src/main/java/org/opencds/cqf/utilities/IOUtils.java
@@ -447,19 +447,21 @@ public class IOUtils
         return list;
     }
 
-    public static String getLibraryPathAssociatedWithCqlFileName(String cqlPath, FhirContext fhirContext) throws FileNotFoundException {
+    public static String getLibraryPathAssociatedWithCqlFileName(String cqlPath, FhirContext fhirContext) {
+        String libraryPath = null;
         String fileName = FilenameUtils.getName(cqlPath);
         String libraryFileName = LibraryProcessor.ResourcePrefix + fileName;
         for (String path : IOUtils.getLibraryPaths(fhirContext)) {
-            // NOTE: A bit of a hack, but we need to support both xml and json encodings for existing resources and the
-            // long-term strategy is to revisit this and change the approach to use the references rather than file name
-            // matching, so this should be good for the near-term.
+            // NOTE: A bit of a hack, but we need to support both xml and json encodings for existing resources and the long-term strategy is
+            // to revisit this and change the approach to use the references rather than file name matching, so this should be good for the near-term.
             if (path.endsWith(libraryFileName.replaceAll(".cql", ".json"))
                 || path.endsWith(libraryFileName.replaceAll(".cql", ".xml"))) {
-                return path;
+                libraryPath = path;
+                break;
             }
         }
-        throw new FileNotFoundException("Could not find a Library Resource Associated with: " + cqlPath);
+
+        return libraryPath;
     }
 
     private static HashSet<String> cqlLibraryPaths = new HashSet<String>();


### PR DESCRIPTION
- Library refresh was writing out generated library rather than preserving the existing
- Fix generated library-type CodeSystem URL
- Fix bug in Library refresh that was causing Content to be duplicated
- Made dependency bundling recursive
- Fixed bug with library not being generated when it doesn't exist.