### PR TITLE
Added IG resource path arg; changed relatedArtifact reference

### DIFF
--- a/src/main/java/org/opencds/cqf/igtools/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/igtools/IGProcessor.java
@@ -73,6 +73,7 @@ public class IGProcessor {
         IOUtils.resourceDirectories.addAll(resourceDirs);
 
         FhirContext fhirContext = getIgFhirContext(igVersion);
+        Boolean igResourcePathIsSpecified = igResourcePath != null && !igResourcePath.isEmpty() && !igResourcePath.isBlank();
         Object implementationGuide = null;
         String igCanonicalBase = null;
 
@@ -83,14 +84,22 @@ public class IGProcessor {
         ArrayList<String> refreshedLibraryNames = null;
         switch (fhirContext.getVersion().getVersion()) {
         case DSTU3:
-            implementationGuide = IOUtils.readResource(igResourcePath, fhirContext, true);
-            igCanonicalBase = IGUtils.getStu3ImplementationGuideCanonicalBase((org.hl7.fhir.dstu3.model.ImplementationGuide)implementationGuide);
+            if (igResourcePathIsSpecified) {
+                implementationGuide = IOUtils.readResource(igResourcePath, fhirContext, true);
+                if (implementationGuide != null) {
+                    igCanonicalBase = IGUtils.getStu3ImplementationGuideCanonicalBase((org.hl7.fhir.dstu3.model.ImplementationGuide) implementationGuide);
+                }
+            }
             refreshedLibraryNames = refreshStu3IG(igCanonicalBase, igPath, encoding, includeELM, includeDependencies, includeTerminology,
                     includePatientScenarios, versioned, fhirContext);
             break;
         case R4:
-            implementationGuide = IOUtils.readResource(igResourcePath, fhirContext, true);
-            igCanonicalBase = IGUtils.getR4ImplementationGuideCanonicalBase((org.hl7.fhir.r4.model.ImplementationGuide)implementationGuide);
+            if (igResourcePathIsSpecified) {
+                implementationGuide = IOUtils.readResource(igResourcePath, fhirContext, true);
+                if (implementationGuide != null) {
+                    igCanonicalBase = IGUtils.getR4ImplementationGuideCanonicalBase((org.hl7.fhir.r4.model.ImplementationGuide) implementationGuide);
+                }
+            }
             refreshedLibraryNames = refreshR4IG(igCanonicalBase, igPath, encoding, includeELM, includeDependencies, includeTerminology,
                     includePatientScenarios, versioned, fhirContext);
             break;

--- a/src/main/java/org/opencds/cqf/igtools/RefreshIGArgumentProcessor.java
+++ b/src/main/java/org/opencds/cqf/igtools/RefreshIGArgumentProcessor.java
@@ -24,6 +24,7 @@ public class RefreshIGArgumentProcessor {
 
     public static final String[] OPERATION_OPTIONS = {"RefreshIG"};
 
+    public static final String[] IG_RESOURCE_PATH_OPTIONS = {"igrp", "ig-resource-path"};
     public static final String[] IG_PATH_OPTIONS = {"ip", "ig-path"};
     public static final String[] IG_VERSION_OPTIONS = {"iv", "ig-version"};
     public static final String[] IG_OUTPUT_ENCODING = {"e", "encoding"};
@@ -38,12 +39,14 @@ public class RefreshIGArgumentProcessor {
     public OptionParser build() {
         OptionParser parser = new OptionParser();
 
+        OptionSpecBuilder igResourcePathBuilder = parser.acceptsAll(asList(IG_RESOURCE_PATH_OPTIONS),"Path to the file containing the ImplementationGuide FHIR Resource.");
         OptionSpecBuilder igPathBuilder = parser.acceptsAll(asList(IG_PATH_OPTIONS),"Limited to a single version of FHIR.");
         OptionSpecBuilder resourcePathBuilder = parser.acceptsAll(asList(RESOURCE_PATH_OPTIONS),"Use multiple times to define multiple resource directories.");
         OptionSpecBuilder igVersionBuilder = parser.acceptsAll(asList(IG_VERSION_OPTIONS),"If omitted the root of the IG Path will be used.");
         OptionSpecBuilder igOutputEncodingBuilder = parser.acceptsAll(asList(IG_OUTPUT_ENCODING), "If omitted, output will be generated using JSON encoding.");
         OptionSpecBuilder fhirUriBuilder = parser.acceptsAll(asList(FHIR_URI_OPTIONS),"If omitted the final bundle will not be loaded to a FHIR server.");
-    
+
+        OptionSpec<String> igResourcePath = igResourcePathBuilder.withRequiredArg().describedAs("Path to the file containing the ImplementationGuide FHIR Resource.");
         OptionSpec<String> igPath = igPathBuilder.withRequiredArg().describedAs("root directory of the ig");
         OptionSpec<String> resourcePath = resourcePathBuilder.withOptionalArg().describedAs("directory of resources");
         OptionSpec<String> igVersion = igVersionBuilder.withOptionalArg().describedAs("ig fhir version");
@@ -70,6 +73,7 @@ public class RefreshIGArgumentProcessor {
 
         ArgUtils.ensure(OPERATION_OPTIONS[0], options);
 
+        String igResourcePath = (String)options.valueOf(IG_RESOURCE_PATH_OPTIONS[0]);
         String igPath = (String)options.valueOf(IG_PATH_OPTIONS[0]);
         List<String> resourcePaths = (List<String>)options.valuesOf(RESOURCE_PATH_OPTIONS[0]);
         //could not easily use the built-in default here because it is based on the value of the igPath argument.
@@ -93,6 +97,7 @@ public class RefreshIGArgumentProcessor {
         paths.addAll(resourcePaths);
     
         RefreshIGParameters ip = new RefreshIGParameters();
+        ip.igResourcePath = igResourcePath;
         ip.igPath = igPath;
         ip.igVersion = IGVersion.parse(igVersion);
         ip.outputEncoding = outputEncodingEnum;

--- a/src/main/java/org/opencds/cqf/igtools/RefreshIGParameters.java
+++ b/src/main/java/org/opencds/cqf/igtools/RefreshIGParameters.java
@@ -8,7 +8,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.opencds.cqf.igtools.IGProcessor.IGVersion;
 import org.opencds.cqf.utilities.IOUtils;
 
-public class RefreshIGParameters {  
+public class RefreshIGParameters {
+    public String igResourcePath;
     public String igPath;
     public IGVersion igVersion;
     public IOUtils.Encoding outputEncoding;

--- a/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
@@ -24,6 +24,8 @@ public class R4LibraryProcessor {
     private static CqfmSoftwareSystemHelper cqfmHelper = new CqfmSoftwareSystemHelper();
 
     public static Boolean refreshLibraryContent(String igCanonicalBase, String cqlContentPath, String libraryPath, FhirContext fhirContext, Encoding encoding, Boolean includeVersion) {
+        CqlTranslator translator = getTranslator(cqlContentPath);
+
         Boolean libraryExists = false;
         Library resource = null;
         if (libraryPath != null) {

--- a/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
@@ -57,8 +57,8 @@ public class R4LibraryProcessor {
         generatedLibrary.getRelatedArtifact().stream()
             .forEach(relatedArtifact -> referenceLibrary.addRelatedArtifact(relatedArtifact));
 
-//        referenceLibrary.getDataRequirement().clear();
-//        generatedLibrary.getDataRequirement().stream().forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
+        referenceLibrary.getDataRequirement().clear();
+        generatedLibrary.getDataRequirement().stream().forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
 
         referenceLibrary.getContent().clear();
         attachContent(referenceLibrary, translator, IOUtils.getCqlString(cqlContentPath));

--- a/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/R4LibraryProcessor.java
@@ -23,25 +23,25 @@ import org.hl7.fhir.r4.model.*;
 public class R4LibraryProcessor {
     private static CqfmSoftwareSystemHelper cqfmHelper = new CqfmSoftwareSystemHelper();
 
-    public static Boolean refreshLibraryContent(String cqlContentPath, String libraryPath, FhirContext fhirContext, Encoding encoding, Boolean includeVersion) {
+    public static Boolean refreshLibraryContent(String igCanonicalBase, String cqlContentPath, String libraryPath, FhirContext fhirContext, Encoding encoding, Boolean includeVersion) {
         Library resource = (Library)IOUtils.readResource(libraryPath, fhirContext, true);
         Boolean libraryExists = resource != null;       
 
         CqlTranslator translator = getTranslator(cqlContentPath);
               
         if (libraryExists) {            
-            refreshLibrary(resource, cqlContentPath, IOUtils.getParentDirectoryPath(libraryPath), encoding, includeVersion, translator, fhirContext);
+            refreshLibrary(igCanonicalBase, resource, cqlContentPath, IOUtils.getParentDirectoryPath(libraryPath), encoding, includeVersion, translator, fhirContext);
         } else {
             Optional<String> anyOtherLibraryDirectory = IOUtils.getLibraryPaths(fhirContext).stream().findFirst();
             String parentDirectory = anyOtherLibraryDirectory.isPresent() ? IOUtils.getParentDirectoryPath(anyOtherLibraryDirectory.get()) : IOUtils.getParentDirectoryPath(cqlContentPath);
-            generateLibrary(cqlContentPath, parentDirectory, encoding, includeVersion, translator, fhirContext);
+            generateLibrary(igCanonicalBase, cqlContentPath, parentDirectory, encoding, includeVersion, translator, fhirContext);
         }
       
         return true;
     }
 
-    private static void refreshLibrary(Library referenceLibrary, String cqlContentPath, String outputPath, Encoding encoding, Boolean includeVersion, CqlTranslator translator, FhirContext fhirContext) {
-        Library generatedLibrary = processLibrary(cqlContentPath, translator, includeVersion, fhirContext);
+    private static void refreshLibrary(String igCanonicalBase, Library referenceLibrary, String cqlContentPath, String outputPath, Encoding encoding, Boolean includeVersion, CqlTranslator translator, FhirContext fhirContext) {
+        Library generatedLibrary = processLibrary(igCanonicalBase, cqlContentPath, translator, includeVersion, fhirContext);
         mergeDiff(referenceLibrary, generatedLibrary, cqlContentPath, translator, fhirContext);
         cqfmHelper.ensureToolingExtensionAndDevice(referenceLibrary);
         IOUtils.writeResource(generatedLibrary, outputPath, encoding, fhirContext);
@@ -51,11 +51,10 @@ public class R4LibraryProcessor {
         FhirContext fhirContext) {
         referenceLibrary.getRelatedArtifact().clear();
         generatedLibrary.getRelatedArtifact().stream()
-                .forEach(relatedArtifact -> referenceLibrary.addRelatedArtifact(relatedArtifact));
+            .forEach(relatedArtifact -> referenceLibrary.addRelatedArtifact(relatedArtifact));
 
-        referenceLibrary.getDataRequirement().clear();
-        generatedLibrary.getDataRequirement().stream()
-                .forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
+//        referenceLibrary.getDataRequirement().clear();
+//        generatedLibrary.getDataRequirement().stream().forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
 
         referenceLibrary.getContent().clear();
         generatedLibrary.getContent().stream()
@@ -66,19 +65,19 @@ public class R4LibraryProcessor {
         referenceLibrary.setText((Narrative)narrative);
     }
 
-    private static void generateLibrary(String cqlContentPath, String outputPath, Encoding encoding, Boolean includeVersion, CqlTranslator translator, FhirContext fhirContext) {
-        Library generatedLibrary = processLibrary(cqlContentPath, translator, includeVersion, fhirContext);
+    private static void generateLibrary(String igCanonicalBase, String cqlContentPath, String outputPath, Encoding encoding, Boolean includeVersion, CqlTranslator translator, FhirContext fhirContext) {
+        Library generatedLibrary = processLibrary(igCanonicalBase, cqlContentPath, translator, includeVersion, fhirContext);
         IOUtils.writeResource(generatedLibrary, outputPath, encoding, fhirContext);
     }
 
-    private static Library processLibrary(String cqlContentPath, CqlTranslator translator, Boolean includeVersion, FhirContext fhirContext) {
+    private static Library processLibrary(String igCanonicalBase, String cqlContentPath, CqlTranslator translator, Boolean includeVersion, FhirContext fhirContext) {
         org.hl7.elm.r1.Library elm = translator.toELM();
         String id = elm.getIdentifier().getId();
         String version = elm.getIdentifier().getVersion();
         Library library = populateMeta(id, version, includeVersion);
         if (elm.getIncludes() != null && !elm.getIncludes().getDef().isEmpty()) {
             for (IncludeDef def : elm.getIncludes().getDef()) {
-                addRelatedArtifact(library, def, includeVersion);
+                addRelatedArtifact(igCanonicalBase, library, def, includeVersion);
             }
         }
 
@@ -108,12 +107,19 @@ public class R4LibraryProcessor {
     }
 
     // Add Related Artifact
-    private static void addRelatedArtifact(Library library, IncludeDef def, Boolean includeVersion) {
+    private static void addRelatedArtifact(String igCanonicalBase, Library library, IncludeDef def, Boolean includeVersion) {
+        if (igCanonicalBase != null) {
+            igCanonicalBase = igCanonicalBase + "/";
+        }
+        else {
+            igCanonicalBase = "";
+        }
+
         library.addRelatedArtifact(
-                new RelatedArtifact()
-                        .setType(RelatedArtifact.RelatedArtifactType.DEPENDSON)
-                        .setResource("Library/" + getIncludedLibraryId(def, includeVersion)) //this is the reference name
-                );
+            new RelatedArtifact()
+                .setType(RelatedArtifact.RelatedArtifactType.DEPENDSON)
+                .setResource(igCanonicalBase + "Library/" + getResourceCanonicalReference(def, includeVersion))
+            );
     }
 
     // Resolve DataRequirements
@@ -158,6 +164,12 @@ public class R4LibraryProcessor {
                         .setContentType("text/cql")
                         .setData(cql.getBytes())
         );
+    }
+
+    private static String getResourceCanonicalReference(IncludeDef def, Boolean includeVersion) {
+        String version = includeVersion ? "|" + def.getVersion() : "";
+        String reference = def.getPath() + version;
+        return reference;
     }
 
     //TODO: need to move to Library Processor

--- a/src/main/java/org/opencds/cqf/library/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/library/STU3LibraryProcessor.java
@@ -57,8 +57,8 @@ public class STU3LibraryProcessor {
         referenceLibrary.getRelatedArtifact().clear();
         generatedLibrary.getRelatedArtifact().stream().forEach(relatedArtifact -> referenceLibrary.addRelatedArtifact(relatedArtifact));
 
-//        referenceLibrary.getDataRequirement().clear();
-//        generatedLibrary.getDataRequirement().stream().forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
+        referenceLibrary.getDataRequirement().clear();
+        generatedLibrary.getDataRequirement().stream().forEach(dateRequirement -> referenceLibrary.addDataRequirement(dateRequirement));
 
         referenceLibrary.getContent().clear();
         attachContent(referenceLibrary, translator, IOUtils.getCqlString(cqlContentPath));

--- a/src/main/java/org/opencds/cqf/utilities/IGUtils.java
+++ b/src/main/java/org/opencds/cqf/utilities/IGUtils.java
@@ -1,0 +1,21 @@
+package org.opencds.cqf.utilities;
+
+public class IGUtils {
+    public static String getStu3ImplementationGuideCanonicalBase(org.hl7.fhir.dstu3.model.ImplementationGuide ig) {
+        String canonicalBase = null;
+        if (ig != null) {
+            String url = ig.getUrl();
+            canonicalBase = url.substring(0, url.indexOf("/ImplementationGuide/"));
+        }
+        return canonicalBase;
+    }
+
+    public static String getR4ImplementationGuideCanonicalBase(org.hl7.fhir.r4.model.ImplementationGuide ig) {
+        String canonicalBase = null;
+        if (ig != null) {
+            String url = ig.getUrl();
+            canonicalBase = url.substring(0, url.indexOf("/ImplementationGuide/"));
+        }
+        return canonicalBase;
+    }
+}


### PR DESCRIPTION
Modifies the way the resource value for relatedArtifacts is generated. 

- Adds the -igrp (IG Resource Path) command argument for RefreshIG
- Loads the Implementation Guide resource and extracts the canonicalBase from its URL
- Passes the IG canonicalBase down to the addRelatedArtifact code
- Related artifact changed to use the canonicalBase along with the "Name" of the CQL library rather than the Library ID for relatedArtifact resource values