### PR TITLE
Fixes #96

### DIFF
--- a/src/main/java/org/opencds/cqf/processor/MeasureProcessor.java
+++ b/src/main/java/org/opencds/cqf/processor/MeasureProcessor.java
@@ -123,7 +123,7 @@ public class MeasureProcessor
 
                 if (includeDependencies) {
                     shouldPersist = shouldPersist
-                        & LibraryProcessor.bundleLibraryDependencies(librarySourcePath, fhirContext, resources, encoding);
+                        & LibraryProcessor.bundleLibraryDependencies(librarySourcePath, fhirContext, resources, encoding, includeVersion);
                 }
 
                 if (includePatientScenarios) {
@@ -208,7 +208,7 @@ public class MeasureProcessor
         }
         
         if (includeDependencies) {
-            Map<String, IAnyResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding);
+            Map<String, IAnyResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding, includeVersion);
             if (!depLibraries.isEmpty()) {
                 String depLibrariesID = "library-deps-" + libraryName;
                 Object bundle = BundleUtils.bundleArtifacts(depLibrariesID, new ArrayList<IAnyResource>(depLibraries.values()), fhirContext);            

--- a/src/main/java/org/opencds/cqf/processor/PlanDefinitionProcessor.java
+++ b/src/main/java/org/opencds/cqf/processor/PlanDefinitionProcessor.java
@@ -82,7 +82,7 @@ public class PlanDefinitionProcessor {
 
                 if (includeDependencies) {
                     shouldPersist = shouldPersist
-                        & LibraryProcessor.bundleLibraryDependencies(librarySourcePath, fhirContext, resources, encoding);
+                        & LibraryProcessor.bundleLibraryDependencies(librarySourcePath, fhirContext, resources, encoding, includeVersion);
                 }
 
                 if (includePatientScenarios) {
@@ -176,7 +176,7 @@ public class PlanDefinitionProcessor {
         }
         
         if (includeDependencies) {
-            Map<String, IAnyResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding);
+            Map<String, IAnyResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding, includeVersion);
             if (!depLibraries.isEmpty()) {
                 String depLibrariesID = "library-deps-" + libraryName;
                 Object bundle = BundleUtils.bundleArtifacts(depLibrariesID, new ArrayList<IAnyResource>(depLibraries.values()), fhirContext);            

--- a/src/main/java/org/opencds/cqf/processor/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/processor/R4LibraryProcessor.java
@@ -76,7 +76,9 @@ public class R4LibraryProcessor implements LibraryProcessor{
         Library generatedLibrary = processLibrary(igCanonicalBase, cqlContentPath, translator, includeVersion, fhirContext);
         mergeDiff(referenceLibrary, generatedLibrary, cqlContentPath, translator, fhirContext);
         cqfmHelper.ensureToolingExtensionAndDevice(referenceLibrary);
-        IOUtils.writeResource(referenceLibrary, outputPath, encoding, fhirContext);
+        // Issue 96
+        // Passing the includeVersion here to handle not using the version number in the filename
+        IOUtils.writeResource(referenceLibrary, outputPath, encoding, fhirContext, includeVersion);
     }
 
     private static void mergeDiff(Library referenceLibrary, Library generatedLibrary, String cqlContentPath, CqlTranslator translator,
@@ -168,7 +170,11 @@ public class R4LibraryProcessor implements LibraryProcessor{
                     //TODO: we probably want to replace this "-library" behavior with a switch (or get rid of it altogether)
                     //HACK: this is not a safe implementation.  Someone could run without -v and everything else would still get the "library-".
                     //Doing this for the connectathon.
-                    .setResource(igCanonicalBase + "Library/" + (includeVersion ? LibraryProcessor.ResourcePrefix : "") + getResourceCanonicalReference(def, includeVersion))
+                    //.setResource(igCanonicalBase + "Library/" + (includeVersion ? LibraryProcessor.ResourcePrefix : "") + getResourceCanonicalReference(def, includeVersion))
+                    // Issue 96
+                    // When not using the -v option we want it to find the files without the version number but we want it
+                    // to generate the dependencies using the version so forcing the includeVersion to true here
+                    .setResource(igCanonicalBase + "Library/" + (includeVersion ? LibraryProcessor.ResourcePrefix : "") + getResourceCanonicalReference(def, true))
             );
         }
         else {


### PR DESCRIPTION
When running without -v option it will still force ids in libraries to include version number but not the filenames