### PR TITLE
Fixes ISS #96 - Allows versioning to be turned off and still works

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/processor/LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/LibraryProcessor.java
@@ -64,14 +64,14 @@ public class LibraryProcessor extends BaseProcessor {
             Encoding encoding, boolean versioned) {
         Boolean shouldPersist = true;
         try {
-            Map<String, IBaseResource> dependencies = ResourceUtils.getDepLibraryResources(path, fhirContext, encoding);
+            Map<String, IBaseResource> dependencies = ResourceUtils.getDepLibraryResources(path, fhirContext, encoding, versioned);
             String currentResourceID = IOUtils.getTypeQualifiedResourceId(path, fhirContext);
             for (IBaseResource resource : dependencies.values()) {
                 resources.putIfAbsent(resource.getIdElement().getIdPart(), resource);
 
                 // NOTE: Assuming dependency library will be in directory of dependent.
                 String dependencyPath = IOUtils.getResourceFileName(IOUtils.getResourceDirectory(path), resource, encoding, fhirContext, versioned);
-                 bundleLibraryDependencies(dependencyPath, fhirContext, resources, encoding, versioned);
+                bundleLibraryDependencies(dependencyPath, fhirContext, resources, encoding, versioned);
             }
         } catch (Exception e) {
             shouldPersist = false;

--- a/src/main/java/org/opencds/cqf/tooling/processor/MeasureProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/MeasureProcessor.java
@@ -209,7 +209,7 @@ public class MeasureProcessor
         }
         
         if (includeDependencies) {
-            Map<String, IBaseResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding);
+            Map<String, IBaseResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding, includeVersion);
             if (!depLibraries.isEmpty()) {
                 String depLibrariesID = "library-deps-" + libraryName;
                 Object bundle = BundleUtils.bundleArtifacts(depLibrariesID, new ArrayList<IBaseResource>(depLibraries.values()), fhirContext);            

--- a/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
@@ -177,7 +177,7 @@ public class PlanDefinitionProcessor {
         }
         
         if (includeDependencies) {
-            Map<String, IBaseResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding);
+            Map<String, IBaseResource> depLibraries = ResourceUtils.getDepLibraryResources(librarySourcePath, fhirContext, encoding, includeVersion);
             if (!depLibraries.isEmpty()) {
                 String depLibrariesID = "library-deps-" + libraryName;
                 Object bundle = BundleUtils.bundleArtifacts(depLibrariesID, new ArrayList<IBaseResource>(depLibraries.values()), fhirContext);            

--- a/src/main/java/org/opencds/cqf/tooling/processor/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/R4LibraryProcessor.java
@@ -80,7 +80,9 @@ public class R4LibraryProcessor extends LibraryProcessor {
                 fileEncoding = encoding;
             }    
             cqfmHelper.ensureCQFToolingExtensionAndDevice(library, fhirContext);
-            IOUtils.writeResource(library, filePath, fileEncoding, fhirContext);
+            // Issue 96
+            // Passing the includeVersion here to handle not using the version number in the filename
+            IOUtils.writeResource(library, filePath, fileEncoding, fhirContext, this.versioned);
             String refreshedLibraryName;
             if (this.versioned && refreshedLibrary.getVersion() != null) {
                 refreshedLibraryName = refreshedLibrary.getName() + "-" + refreshedLibrary.getVersion();
@@ -234,8 +236,12 @@ public class R4LibraryProcessor extends LibraryProcessor {
                     //TODO: we probably want to replace this "-library" behavior with a switch (or get rid of it altogether)
                     //HACK: this is not a safe implementation.  Someone could run without -v and everything else would still get the "library-".
                     //Doing this for the connectathon.
-                    .setResource(igCanonicalBase + "Library/" + (includeVersion ? LibraryProcessor.ResourcePrefix : "") + getResourceCanonicalReference(def, includeVersion))
-            );
+                    //.setResource(igCanonicalBase + "Library/" + (includeVersion ? LibraryProcessor.ResourcePrefix : "") + getResourceCanonicalReference(def, includeVersion))
+                    // Issue 96
+                    // When not using the -v option we want it to find the files without the version number but we want it
+                    // to generate the dependencies using the version so forcing the includeVersion to true here
+                    .setResource(igCanonicalBase + "Library/" + (includeVersion ? LibraryProcessor.ResourcePrefix : "") + getResourceCanonicalReference(def, true))
+                    );
         }
         else {
             if (includeVersion) {

--- a/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -286,7 +286,13 @@ public class IOUtils
         	if (index > 0) {
         		filename = filename.substring(0, index - 1);
         	}
+        } else if (versioned && resourceVersion != null) {
+            int index = filename.indexOf(resourceVersion);
+            if (index < 0) {
+                filename = filename + "-" + resourceVersion;
+            }
         }
+        
         String result = Paths.get(resourcePath, resource.getIdElement().getResourceType().toLowerCase(), filename) + getFileExtension(encoding);
         return result;
     }

--- a/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -287,7 +287,7 @@ public class IOUtils
         		filename = filename.substring(0, index - 1);
         	}
         }
-        String result = Paths.get(resourcePath, resource.getIdElement().getResourceType(), filename) + getFileExtension(encoding);
+        String result = Paths.get(resourcePath, resource.getIdElement().getResourceType().toLowerCase(), filename) + getFileExtension(encoding);
         return result;
     }
 

--- a/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -116,39 +116,46 @@ public class ResourceUtils
       return ((org.hl7.fhir.r4.model.Library)mainLibrary).getRelatedArtifact();   
     }    
 
-    public static Map<String, IBaseResource> getDepLibraryResources(String path, FhirContext fhirContext, Encoding encoding) {      
+    public static Map<String, IBaseResource> getDepLibraryResources(String path, FhirContext fhirContext, Encoding encoding, Boolean versioned) {      
       Map<String, IBaseResource> dependencyLibraries = new HashMap<String, IBaseResource>();
       switch (fhirContext.getVersion().getVersion()) {
         case DSTU3:
-            return getStu3DepLibraryResources(path, dependencyLibraries, fhirContext, encoding);
+            return getStu3DepLibraryResources(path, dependencyLibraries, fhirContext, encoding, versioned);
         case R4:
-            return getR4DepLibraryResources(path, dependencyLibraries, fhirContext, encoding);
+            return getR4DepLibraryResources(path, dependencyLibraries, fhirContext, encoding, versioned);
         default:
             throw new IllegalArgumentException("Unknown fhir version: " + fhirContext.getVersion().getVersion().getFhirVersionString());
       }
     }
 
-    public static List<String> getDepLibraryPaths(String path, FhirContext fhirContext, Encoding encoding) {
+    public static List<String> getDepLibraryPaths(String path, FhirContext fhirContext, Encoding encoding, Boolean versioned) {
       switch (fhirContext.getVersion().getVersion()) {
         case DSTU3:
-            return getStu3DepLibraryPaths(path, fhirContext, encoding);
+            return getStu3DepLibraryPaths(path, fhirContext, encoding, versioned);
         case R4:
-            return getR4DepLibraryPaths(path, fhirContext, encoding);
+            return getR4DepLibraryPaths(path, fhirContext, encoding,versioned);
         default:
             throw new IllegalArgumentException("Unknown fhir version: " + fhirContext.getVersion().getVersion().getFhirVersionString());
       }
     }
 
-    private static List<String> getStu3DepLibraryPaths(String path, FhirContext fhirContext, Encoding encoding) {
+    private static List<String> getStu3DepLibraryPaths(String path, FhirContext fhirContext, Encoding encoding, Boolean versioned) {
       List<String> paths = new ArrayList<String>();
       String directoryPath = FilenameUtils.getFullPath(path);
       List<org.hl7.fhir.dstu3.model.RelatedArtifact> relatedArtifacts = getStu3RelatedArtifacts(path, fhirContext);
       for (org.hl7.fhir.dstu3.model.RelatedArtifact relatedArtifact : relatedArtifacts) {
         if (relatedArtifact.getType() == org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DEPENDSON) {
             if (relatedArtifact.getResource().getReference().contains("Library/")) {
-                String dependencyLibraryName = IOUtils.formatFileName(relatedArtifact.getResource().getReference().split("Library/")[1].replaceAll("\\|", "-"), encoding, fhirContext);
+                String dependencyLibraryName;
+                // Issue 96 - Do not include version number in the filename
+                if (versioned) {
+              	  dependencyLibraryName = IOUtils.formatFileName(relatedArtifact.getResource().getReference().split("Library/")[1].replaceAll("\\|", "-"), encoding, fhirContext);
+                } else {
+              	  String name = relatedArtifact.getResource().getReference().split("Library/")[1];
+              	  dependencyLibraryName = IOUtils.formatFileName(name.split("\\|")[0], encoding, fhirContext);
+                }
                 String dependencyLibraryPath = FilenameUtils.concat(directoryPath, dependencyLibraryName);
-                IOUtils.putAllInListIfAbsent(getStu3DepLibraryPaths(dependencyLibraryPath, fhirContext, encoding), paths);
+                IOUtils.putAllInListIfAbsent(getStu3DepLibraryPaths(dependencyLibraryPath, fhirContext, encoding, versioned), paths);
                 IOUtils.putInListIfAbsent(dependencyLibraryPath, paths);
             }
         }
@@ -156,8 +163,8 @@ public class ResourceUtils
       return paths;
     }
 
-    private static Map<String, IBaseResource> getStu3DepLibraryResources(String path, Map<String, IBaseResource> dependencyLibraries, FhirContext fhirContext, Encoding encoding) {      
-      List<String> dependencyLibraryPaths = getStu3DepLibraryPaths(path, fhirContext, encoding);
+    private static Map<String, IBaseResource> getStu3DepLibraryResources(String path, Map<String, IBaseResource> dependencyLibraries, FhirContext fhirContext, Encoding encoding, Boolean versioned) {      
+      List<String> dependencyLibraryPaths = getStu3DepLibraryPaths(path, fhirContext, encoding, versioned);
       for (String dependencyLibraryPath : dependencyLibraryPaths) {
         Object resource = IOUtils.readResource(dependencyLibraryPath, fhirContext);
         if (resource instanceof org.hl7.fhir.dstu3.model.Library) {
@@ -169,14 +176,21 @@ public class ResourceUtils
     }
 
     // if | exists there is a version
-    private static List<String> getR4DepLibraryPaths(String path, FhirContext fhirContext, Encoding encoding) {
+    private static List<String> getR4DepLibraryPaths(String path, FhirContext fhirContext, Encoding encoding, Boolean versioned) {
       List<String> paths = new ArrayList<String>();
       String directoryPath = FilenameUtils.getFullPath(path);
       List<org.hl7.fhir.r4.model.RelatedArtifact> relatedArtifacts = getR4RelatedArtifacts(path, fhirContext);
       for (org.hl7.fhir.r4.model.RelatedArtifact relatedArtifact : relatedArtifacts) {
           if (relatedArtifact.getType() == org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DEPENDSON) {
               if (relatedArtifact.getResource().contains("Library/")) {
-                  String dependencyLibraryName = IOUtils.formatFileName(relatedArtifact.getResource().split("Library/")[1].replaceAll("\\|", "-"), encoding, fhirContext);
+            	  String dependencyLibraryName;
+                  // Issue 96 - Do not include version number in the filename
+                  if (versioned) {
+                	  dependencyLibraryName = IOUtils.formatFileName(relatedArtifact.getResource().split("Library/")[1].replaceAll("\\|", "-"), encoding, fhirContext);
+                  } else {
+                	  String name = relatedArtifact.getResource().split("Library/")[1];
+                	  dependencyLibraryName = IOUtils.formatFileName(name.split("\\|")[0], encoding, fhirContext);
+                  }
                   String dependencyLibraryPath = FilenameUtils.concat(directoryPath, dependencyLibraryName);
                   IOUtils.putInListIfAbsent(dependencyLibraryPath, paths);
               }
@@ -185,8 +199,8 @@ public class ResourceUtils
       return paths;
     }
 
-    private static Map<String, IBaseResource> getR4DepLibraryResources(String path, Map<String, IBaseResource> dependencyLibraries, FhirContext fhirContext, Encoding encoding) {      
-      List<String> dependencyLibraryPaths = getR4DepLibraryPaths(path, fhirContext, encoding);
+    private static Map<String, IBaseResource> getR4DepLibraryResources(String path, Map<String, IBaseResource> dependencyLibraries, FhirContext fhirContext, Encoding encoding, Boolean versioned) {      
+      List<String> dependencyLibraryPaths = getR4DepLibraryPaths(path, fhirContext, encoding, versioned);
       for (String dependencyLibraryPath : dependencyLibraryPaths) {
         Object resource = IOUtils.readResource(dependencyLibraryPath, fhirContext);
         if (resource instanceof org.hl7.fhir.r4.model.Library) {


### PR DESCRIPTION
Allows versioning to be turned off and still works without the libraries needing to be named with the version number in them