### PR TITLE
Test data was bundling the resource types into transaction bundles 

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/processor/TestCaseProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/TestCaseProcessor.java
@@ -91,7 +91,9 @@ public class TestCaseProcessor
         try {
             List<IBaseResource> testCaseResources = TestCaseProcessor.getTestCaseResources(igTestCasePath, fhirContext);
             for (IBaseResource resource : testCaseResources) {
-                resources.putIfAbsent(resource.getIdElement().getIdPart(), resource);
+            	if ((!(resource instanceof org.hl7.fhir.dstu3.model.Bundle)) && (!(resource instanceof org.hl7.fhir.r4.model.Bundle))) {
+            		resources.putIfAbsent(resource.getIdElement().getIdPart(), resource);
+            	}
             }
         } catch (Exception e) {
             shouldPersist = false;


### PR DESCRIPTION
that were being included in the existing transaction bundle that caused an issue. Just checked that resource is not a bundle before adding it for test resources.