### PR TITLE
Upgraded the <hapi.version> to align with the work going on in the ha…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cqframework.version>1.5.1-SNAPSHOT</cqframework.version>
-        <hapi.version>5.0.2</hapi.version>
+        <cqframework.version>1.5.1</cqframework.version>
+        <!-- TODO: Change this to a hapi-fhir released version (e.g. 5.3.0) before finalizing this work! kevin.dougan@smilecdr.com -->
+        <hapi.version>5.3.0-SNAPSHOT</hapi.version>
         <core.version>5.0.22</core.version>
     </properties>
 


### PR DESCRIPTION
Upgraded the <hapi.version> to align with the work going on in the hapi-fhir CQL branches. Also, removed -SNAPSHOT from the <cqframework.version> since I am not building that component locally.

NOTE: I am using a SNAPSHOT version of hapi-fhir in this POM because this is part of our work-in-progress for the CQL refactoring.
