### PR TITLE
Fix baseprocessor stu3 support

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
+++ b/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
@@ -6,8 +6,6 @@ import org.opencds.cqf.tooling.utilities.IOUtils;
 
 public class RefreshIGParameters {
     public String ini;
-    public String rootDir;
-    public String igPath;
     public IOUtils.Encoding outputEncoding;
     public Boolean includeELM;
     public Boolean includeDependencies;

--- a/src/main/java/org/opencds/cqf/tooling/processor/BaseProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/BaseProcessor.java
@@ -1,15 +1,24 @@
 package org.opencds.cqf.tooling.processor;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.fhir.ucum.UcumService;
-import org.hl7.fhir.convertors.VersionConvertor_40_50;
-import org.hl7.fhir.r4.formats.FormatUtilities;
-import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.hl7.fhir.convertors.VersionConvertor_30_40;
+import org.hl7.fhir.convertors.VersionConvertor_30_50;
+import org.hl7.fhir.convertors.VersionConvertor_40_50;
+import org.hl7.fhir.r5.formats.FormatUtilities;
+import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.utilities.IniFile;
+import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.VersionUtilities;
 import org.opencds.cqf.tooling.npm.NpmPackageManager;
 
 public class BaseProcessor implements IProcessorContext, IWorkerContext.ILoggingService {
@@ -65,7 +74,7 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
         }
     }
 
-    public void initialize(String rootDir, String igPath) {
+    public void initialize(String rootDir, String igPath, String fhirVersion) {
         this.rootDir = rootDir;
 
         try {
@@ -75,13 +84,11 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
             logMessage(String.format("Exceptions occurred extracting path from ig", e.getMessage()));
         }
 
-        try {
-            sourceIg = (ImplementationGuide) VersionConvertor_40_50.convertResource(FormatUtilities.loadFile(igPath));
-        }
-        catch (IOException e) {
-            logMessage(String.format("Exceptions occurred loading IG file", e.getMessage()));
-        }
-        fhirVersion = sourceIg.getFhirVersion().get(0).getCode();
+        ImplementationGuide sourceIg = loadSourceIG(igPath, fhirVersion);
+
+        // TODO: Perhaps we should validate the passed in fhirVersion against the fhirVersion in the IG?
+
+        this.fhirVersion = sourceIg.getFhirVersion().get(0).getCode();
         packageId = sourceIg.getPackageId();
         canonicalBase = determineCanonical(sourceIg.getUrl());
         try {
@@ -99,7 +106,36 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
         IniFile ini = new IniFile(new File(iniFile).getAbsolutePath());
         String rootDir = Utilities.getDirectoryForFile(ini.getFileName());
         String igPath = ini.getStringProperty("IG", "ig");
-        initialize(rootDir, igPath);
+        String specifiedFhirVersion = ini.getStringProperty("IG", "fhir-version");
+        if (specifiedFhirVersion == null || specifiedFhirVersion == "") {
+            logMessage("fhir-version was not specified in the ini file. Trying FHIR version 4.0.1");
+            specifiedFhirVersion = "4.0.1";
+        }
+        initialize(rootDir, igPath, specifiedFhirVersion);
+    }
+
+    private ImplementationGuide loadSourceIG(String igPath, String specifiedFhirVersion) {
+        ImplementationGuide sourceIG = null;
+        try {
+            if (VersionUtilities.isR3Ver(specifiedFhirVersion)) {
+                byte[] src = TextFile.fileToBytes(igPath);
+                Manager.FhirFormat fmt = org.hl7.fhir.r5.formats.FormatUtilities.determineFormat(src);
+                org.hl7.fhir.dstu3.formats.ParserBase parser = org.hl7.fhir.dstu3.formats.FormatUtilities.makeParser(fmt.toString());
+                sourceIg = (ImplementationGuide) VersionConvertor_30_50.convertResource(parser.parse(src), false);
+            } else if (VersionUtilities.isR4Ver(specifiedFhirVersion)) {
+                org.hl7.fhir.r4.model.Resource res = org.hl7.fhir.r4.formats.FormatUtilities.loadFile(igPath);
+                sourceIg = (ImplementationGuide) VersionConvertor_40_50.convertResource(res);
+            } else if (VersionUtilities.isR5Ver(specifiedFhirVersion)) {
+                sourceIg = (ImplementationGuide) org.hl7.fhir.r5.formats.FormatUtilities.loadFile(igPath);
+            } else {
+                throw new FHIRException("Unknown Version '"+specifiedFhirVersion+"'");
+            }
+        }
+        catch (IOException e) {
+            logMessage(String.format("Exceptions occurred loading IG file", e.getMessage()));
+        }
+
+        return sourceIg;
     }
 
     private String determineCanonical(String url) {

--- a/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
@@ -346,37 +346,45 @@ public class CqlProcessor {
                 result.getErrors().add(new ValidationMessage(ValidationMessage.Source.Publisher, IssueType.EXCEPTION, file.getName(),
                         String.format("CQL Processing failed with (%d) errors.", translator.getErrors().size()), IssueSeverity.ERROR));
                 logger.logMessage(String.format("Translation failed with (%d) errors; see the error log for more information.", translator.getErrors().size()));
+
+                for (CqlTranslatorException error : translator.getErrors()) {
+                    logger.logMessage(String.format("Error: %s", error.getMessage()));
+                }
             }
             else {
-                // convert to base64 bytes
-                // NOTE: Publication tooling requires XML content
-                result.setElm(translator.toXml().getBytes());
-                result.setIdentifier(translator.toELM().getIdentifier());
-                if (options.getFormats().contains(CqlTranslator.Format.JSON)) {
-                    result.setJsonElm(translator.toJson().getBytes());
+                try {
+                    // convert to base64 bytes
+                    // NOTE: Publication tooling requires XML content
+                    result.setElm(translator.toXml().getBytes());
+                    result.setIdentifier(translator.toELM().getIdentifier());
+                    if (options.getFormats().contains(CqlTranslator.Format.JSON)) {
+                        result.setJsonElm(translator.toJson().getBytes());
+                    }
+                    if (options.getFormats().contains(CqlTranslator.Format.JXSON)) {
+                        result.setJsonElm(translator.toJxson().getBytes());
+                    }
+
+                    // TODO: Report context, requires 1.5 translator (ContextDef)
+                    // NOTE: In STU3, only Patient context is supported
+
+                    // Extract relatedArtifact data (models, libraries, code systems, and value sets)
+                    result.relatedArtifacts.addAll(extractRelatedArtifacts(translator.toELM()));
+
+                    // Extract parameter data and validate result types are supported types
+                    List<ValidationMessage> paramMessages = new ArrayList<>();
+                    result.parameters.addAll(extractParameters(translator.toELM(), paramMessages));
+                    for (ValidationMessage paramMessage : paramMessages) {
+                        result.getErrors().add(new ValidationMessage(paramMessage.getSource(), paramMessage.getType(), file.getName(),
+                                paramMessage.getMessage(), paramMessage.getLevel()));
+                    }
+
+                    // Extract dataRequirement data
+                    result.dataRequirements.addAll(extractDataRequirements(translator.toRetrieves(), translator.getTranslatedLibrary(), libraryManager));
+
+                    logger.logMessage("CQL translation completed successfully.");
+                } catch (Exception ex) {
+                    logger.logMessage(String.format("CQL Translation succeeded for file: '%s', but ELM generation failed with the following error: %s", file.getAbsolutePath(), ex.getMessage()));
                 }
-                if (options.getFormats().contains(CqlTranslator.Format.JXSON)) {
-                    result.setJsonElm(translator.toJxson().getBytes());
-                }
-
-                // TODO: Report context, requires 1.5 translator (ContextDef)
-                // NOTE: In STU3, only Patient context is supported
-
-                // Extract relatedArtifact data (models, libraries, code systems, and value sets)
-                result.relatedArtifacts.addAll(extractRelatedArtifacts(translator.toELM()));
-
-                // Extract parameter data and validate result types are supported types
-                List<ValidationMessage> paramMessages = new ArrayList<>();
-                result.parameters.addAll(extractParameters(translator.toELM(), paramMessages));
-                for (ValidationMessage paramMessage : paramMessages) {
-                    result.getErrors().add(new ValidationMessage(paramMessage.getSource(), paramMessage.getType(), file.getName(),
-                            paramMessage.getMessage(), paramMessage.getLevel()));
-                }
-
-                // Extract dataRequirement data
-                result.dataRequirements.addAll(extractDataRequirements(translator.toRetrieves(), translator.getTranslatedLibrary(), libraryManager));
-
-                logger.logMessage("CQL translation completed successfully.");
             }
         }
         catch (Exception e) {

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -20,9 +20,6 @@ public class IGProcessor extends BaseProcessor {
         if (params.ini != null) {
             initialize(params.ini);
         }
-        else {
-            initialize(params.rootDir, params.igPath);
-        }
 
         Encoding encoding = params.outputEncoding;
         Boolean includeELM = params.includeELM;
@@ -37,7 +34,7 @@ public class IGProcessor extends BaseProcessor {
 
         IOUtils.resourceDirectories.addAll(resourceDirs);
 
-        FhirContext fhirContext = IGProcessor.getIgFhirContext(fhirVersion);
+        FhirContext fhirContext = IGProcessor.getIgFhirContext(this.getFhirVersion());
 
         //Use case 1
         //Scaffold basic templating for the type of content, Measure, PlanDefinition, or Questionnaire
@@ -67,9 +64,6 @@ public class IGProcessor extends BaseProcessor {
     public void refreshIG(RefreshIGParameters params) {
         if (params.ini != null) {
             initialize(params.ini);
-        }
-        else {
-            initialize(params.rootDir, params.igPath);
         }
 
         Encoding encoding = params.outputEncoding;

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGTestProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGTestProcessor.java
@@ -162,7 +162,7 @@ public class IGTestProcessor extends BaseProcessor {
             initialize(params.ini);
         }
         else {
-            initialize(params.rootDir, params.igPath);
+            initialize(params.rootDir, params.igPath, fhirContext.getVersion().toString());
         }
 
         CqfmSoftwareSystem testTargetSoftwareSystem =  getCqfRulerSoftwareSystem(params.fhirServerUri);

--- a/src/main/java/org/opencds/cqf/tooling/processor/LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/LibraryProcessor.java
@@ -134,7 +134,7 @@ public class LibraryProcessor extends BaseProcessor {
                 sourceLibrary.getParameter().clear();
                 sourceLibrary.getParameter().addAll(info.getParameters());
             } else {
-                logMessage(String.format(String.format("No cql info found for ", fileName)));
+                logMessage(String.format("No cql info found for ", fileName));
                 //f.getErrors().add(new ValidationMessage(ValidationMessage.Source.Publisher, ValidationMessage.IssueType.NOTFOUND, "Library", "No cql info found for "+f.getName(), ValidationMessage.IssueSeverity.ERROR));
             }
         }

--- a/src/main/java/org/opencds/cqf/tooling/processor/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/R4LibraryProcessor.java
@@ -42,27 +42,11 @@ public class R4LibraryProcessor extends LibraryProcessor {
 
         if (file.isDirectory()) {
             for (File libraryFile : file.listFiles()) {
-                org.hl7.fhir.r4.model.Resource resource = null;
-                try {
-                    resource = FormatUtilities.loadFile(libraryFile.getAbsolutePath());
-                } catch (IOException e) {
-                    logMessage(String.format("Exceptions occurred loading resource file %s", libraryFile.getAbsolutePath()));
-                }
-                org.hl7.fhir.r5.model.Library library = (org.hl7.fhir.r5.model.Library) VersionConvertor_40_50.convertResource(resource);
-                fileMap.put(library.getId(), libraryFile.getAbsolutePath());
-                libraries.add(library);
+                loadLibrary(fileMap, libraries, libraryFile);
             }
         }
         else {
-            org.hl7.fhir.r4.model.Resource resource = null;
-            try {
-                resource = FormatUtilities.loadFile(file.getAbsolutePath());
-            } catch (IOException e) {
-                logMessage(String.format("Exceptions occurred loading resource file %s", file.getAbsolutePath()));
-            }
-            org.hl7.fhir.r5.model.Library library = (org.hl7.fhir.r5.model.Library) VersionConvertor_40_50.convertResource(resource);
-            fileMap.put(library.getId(), file.getAbsolutePath());
-            libraries.add(library);
+            loadLibrary(fileMap, libraries, file);
         }
 
         List<String> refreshedLibraryNames = new ArrayList<String>();
@@ -93,6 +77,17 @@ public class R4LibraryProcessor extends LibraryProcessor {
         }
 
         return refreshedLibraryNames;
+    }
+
+    private void loadLibrary(Map<String, String> fileMap, List<org.hl7.fhir.r5.model.Library> libraries, File libraryFile) {
+        try {
+            Resource resource = FormatUtilities.loadFile(libraryFile.getAbsolutePath());
+            org.hl7.fhir.r5.model.Library library = (org.hl7.fhir.r5.model.Library) VersionConvertor_40_50.convertResource(resource);
+            fileMap.put(library.getId(), libraryFile.getAbsolutePath());
+            libraries.add(library);
+        } catch (IOException ex) {
+            logMessage(String.format("Error reading library: %s. Error: %s", libraryFile.getAbsolutePath(), ex.getMessage()));
+        }
     }
 
     @Override

--- a/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
@@ -39,17 +39,11 @@ public class STU3LibraryProcessor extends LibraryProcessor {
         List<org.hl7.fhir.r5.model.Library> libraries = new ArrayList<>();
         if (file.isDirectory()) {
             for (File libraryFile : file.listFiles()) {
-                org.hl7.fhir.dstu3.model.Resource resource = (org.hl7.fhir.dstu3.model.Resource) IOUtils.readResource(libraryFile.getAbsolutePath(), fhirContext);
-                org.hl7.fhir.r5.model.Library library = (org.hl7.fhir.r5.model.Library) VersionConvertor_30_50.convertResource(resource, false);
-                fileMap.put(library.getId(), libraryFile.getAbsolutePath());
-                libraries.add(library);
+                loadLibrary(fileMap, libraries, libraryFile);
             }
         }
         else {
-            org.hl7.fhir.dstu3.model.Resource resource = (org.hl7.fhir.dstu3.model.Resource) IOUtils.readResource(file.getAbsolutePath(), fhirContext);
-            org.hl7.fhir.r5.model.Library library = (org.hl7.fhir.r5.model.Library) VersionConvertor_30_50.convertResource(resource, false);
-            fileMap.put(library.getId(), file.getAbsolutePath());
-            libraries.add(library);
+            loadLibrary(fileMap, libraries, file);
         }
 
         List<String> refreshedLibraryNames = new ArrayList<String>();
@@ -69,6 +63,17 @@ public class STU3LibraryProcessor extends LibraryProcessor {
         }
 
         return refreshedLibraryNames;
+    }
+
+    private void loadLibrary(Map<String, String> fileMap, List<org.hl7.fhir.r5.model.Library> libraries, File libraryFile) {
+        try {
+            Resource resource = (Resource) IOUtils.readResource(libraryFile.getAbsolutePath(), fhirContext);
+            org.hl7.fhir.r5.model.Library library = (org.hl7.fhir.r5.model.Library) VersionConvertor_30_50.convertResource(resource, false);
+            fileMap.put(library.getId(), libraryFile.getAbsolutePath());
+            libraries.add(library);
+        } catch (Exception ex) {
+            logMessage(String.format("Error reading library: %s. Error: %s", libraryFile.getAbsolutePath(), ex.getMessage()));
+        }
     }
 
     @Override

--- a/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
@@ -20,8 +20,6 @@ public class RefreshIGArgumentProcessor {
     public static final String[] OPERATION_OPTIONS = {"RefreshIG"};
 
     public static final String[] INI_OPTIONS = {"ini"};
-    public static final String[] ROOT_DIR_OPTIONS = {"root-dir"};
-    public static final String[] IG_PATH_OPTIONS = {"ip", "ig-path"};
     public static final String[] IG_OUTPUT_ENCODING = {"e", "encoding"};
     public static final String[] INCLUDE_ELM_OPTIONS = {"elm", "include-elm"};
     public static final String[] INCLUDE_DEPENDENCY_LIBRARY_OPTIONS = {"d", "include-dependencies"};
@@ -37,16 +35,12 @@ public class RefreshIGArgumentProcessor {
         OptionParser parser = new OptionParser();
 
         OptionSpecBuilder iniBuilder = parser.acceptsAll(asList(INI_OPTIONS), "Path to ig ini file");
-        OptionSpecBuilder rootDirBuilder = parser.acceptsAll(asList(ROOT_DIR_OPTIONS), "Root directory of the ig");
-        OptionSpecBuilder igPathBuilder = parser.acceptsAll(asList(IG_PATH_OPTIONS),"Path to the IG, relative to the root directory");
         OptionSpecBuilder resourcePathBuilder = parser.acceptsAll(asList(RESOURCE_PATH_OPTIONS),"Use multiple times to define multiple resource directories.");
         OptionSpecBuilder igOutputEncodingBuilder = parser.acceptsAll(asList(IG_OUTPUT_ENCODING), "If omitted, output will be generated using JSON encoding.");
         OptionSpecBuilder fhirUriBuilder = parser.acceptsAll(asList(FHIR_URI_OPTIONS),"If omitted the final bundle will not be loaded to a FHIR server.");
         OptionSpecBuilder measureToRefreshPathBuilder = parser.acceptsAll(asList(MEASURE_TO_REFRESH_PATH), "Path to Measure to refresh.");
 
-        OptionSpec<String> ini = iniBuilder.withOptionalArg().describedAs("Path to the IG ini file");
-        OptionSpec<String> rootDir = rootDirBuilder.withOptionalArg().describedAs("Root directory of the IG");
-        OptionSpec<String> igPath = igPathBuilder.withRequiredArg().describedAs("Path to the IG, relative to the root directory");
+        OptionSpec<String> ini = iniBuilder.withRequiredArg().describedAs("Path to the IG ini file");
         OptionSpec<String> resourcePath = resourcePathBuilder.withOptionalArg().describedAs("directory of resources");
         OptionSpec<String> igOutputEncoding = igOutputEncodingBuilder.withOptionalArg().describedAs("desired output encoding for resources");
         OptionSpec<String> measureToRefreshPath = measureToRefreshPathBuilder.withOptionalArg().describedAs("Path to Measure to refresh.");
@@ -75,9 +69,6 @@ public class RefreshIGArgumentProcessor {
 
         String ini = (String)options.valueOf(INI_OPTIONS[0]);
 
-        String rootDir = (String)options.valueOf(ROOT_DIR_OPTIONS[0]);
-        String igPath = (String)options.valueOf(IG_PATH_OPTIONS[0]);
-
         List<String> resourcePaths = ArgUtils.getOptionValues(options, RESOURCE_PATH_OPTIONS[0]);
             
         //could not easily use the built-in default here because it is based on the value of the igPath argument.
@@ -102,8 +93,6 @@ public class RefreshIGArgumentProcessor {
     
         RefreshIGParameters ip = new RefreshIGParameters();
         ip.ini = ini;
-        ip.rootDir = rootDir;
-        ip.igPath = igPath;
         ip.outputEncoding = outputEncodingEnum;
         ip.includeELM = includeELM;
         ip.includeDependencies = includeDependencies;

--- a/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -709,7 +709,7 @@ public class IOUtils
                 try {
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
-                    //TODO: handle exception
+                    System.out.println(String.format("Error setting PlanDefinition paths while reading resource at: '%s'. Error: %s", path, e.getMessage()));
                 }
             }
             RuntimeResourceDefinition planDefinitionDefinition = (RuntimeResourceDefinition)ResourceUtils.getResourceDefinition(fhirContext, "PlanDefinition");

--- a/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -271,7 +271,7 @@ public class ResourceUtils
       try {
         elm = getElmFromCql(cqlContentPath);
       } catch (Exception e) {
-        System.out.println("error proccessing cql: ");
+        System.out.println("error processing cql: ");
         System.out.println(e.getMessage());
         return includedDefs;
       }


### PR DESCRIPTION
.ini file is now required and must contain 'fhir-version' setting with a version number value (e.g., 3.0.2, 4.0.1). 
Updated the BaseProcessor to support dstu3 rather than assuming R4.
Improved error messaging/logging throughout CQL translation and refresh.