### PR TITLE
Fix stu3 relatedartifact reference

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
@@ -70,13 +70,11 @@ public class STU3LibraryProcessor extends LibraryProcessor {
 
     private void cleanseRelatedArtifactReferences(Library library) {
         for (RelatedArtifact relatedArtifact : library.getRelatedArtifact()) {
-            if (relatedArtifact.getType() == RelatedArtifact.RelatedArtifactType.DEPENDSON) {
-                if (relatedArtifact.hasResource()) {
-                    String resourceReference = relatedArtifact.getResource().getReference();
-                    if (resourceReference.contains("|")) {
-                        String curatedResourceReference = resourceReference.substring(0, resourceReference.indexOf("|"));
-                        relatedArtifact.getResource().setReference(curatedResourceReference);
-                    }
+            if ((relatedArtifact.getType() == RelatedArtifact.RelatedArtifactType.DEPENDSON) && relatedArtifact.hasResource()) {
+                String resourceReference = relatedArtifact.getResource().getReference();
+                if (resourceReference.contains("|")) {
+                    String curatedResourceReference = resourceReference.substring(0, resourceReference.indexOf("|"));
+                    relatedArtifact.getResource().setReference(curatedResourceReference);
                 }
             }
         }


### PR DESCRIPTION
This resolves a bug in the generation of relatedArtifact references for DSTU3 Libraries when refreshing. Specifically, the STU3LibraryProcessor will no remove the version from relatedArtifact references.