### PR TITLE
Added cleanse step, post-translation, for CodeSystem resolution worka…

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
@@ -69,7 +69,11 @@ public class STU3LibraryProcessor extends LibraryProcessor {
     }
 
     private void cleanseRelatedArtifactReferences(Library library) {
-        for (RelatedArtifact relatedArtifact : library.getRelatedArtifact()) {
+        List<String> unresolvableCodeSystems = Arrays.asList("http://loinc.org", "http://snomed.info/sct");
+        List<RelatedArtifact> relatedArtifacts = library.getRelatedArtifact();
+        relatedArtifacts.removeIf(ra -> ra.hasResource() && ra.getResource().hasReference() && unresolvableCodeSystems.contains(ra.getResource().getReference()));
+
+        for (RelatedArtifact relatedArtifact : relatedArtifacts) {
             if ((relatedArtifact.getType() == RelatedArtifact.RelatedArtifactType.DEPENDSON) && relatedArtifact.hasResource()) {
                 String resourceReference = relatedArtifact.getResource().getReference();
                 if (resourceReference.contains("|")) {


### PR DESCRIPTION
…round.

STU3LibraryProcessor Cleanse of CodeSystem references that will not resolve.

Added a "cleanse" step to the STU3LibraryProcessor so that after translation, CodeSystems that will not resolve (known and explicitly specified set) can be removed from the relatedArtifacts of the Library.

Added cleanseRelatedArtifactsReferences method and call it from refreshLibraries post-translation.

- [ ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [ ] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
