### PR TITLE
Update org.hl7 dependencies to version 5.2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <cqframework.version>1.5.1</cqframework.version>
         <!-- TODO: Change this to a hapi-fhir released version (e.g. 5.3.0) before finalizing this work! kevin.dougan@smilecdr.com -->
         <hapi.version>5.3.0-SNAPSHOT</hapi.version>
-        <core.version>5.0.22</core.version>
+        <core.version>5.2.16</core.version>
     </properties>
 
     <name>cqf-tooling</name>

--- a/src/main/java/org/opencds/cqf/tooling/npm/NpmLibrarySourceProvider.java
+++ b/src/main/java/org/opencds/cqf/tooling/npm/NpmLibrarySourceProvider.java
@@ -9,7 +9,7 @@ import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.Library;
-import org.hl7.fhir.utilities.cache.NpmPackage;
+import org.hl7.fhir.utilities.npm.NpmPackage;
 
 /**
  * Provides a library source provider that can resolve CQL library source from an Npm package

--- a/src/main/java/org/opencds/cqf/tooling/npm/NpmPackageManager.java
+++ b/src/main/java/org/opencds/cqf/tooling/npm/NpmPackageManager.java
@@ -19,9 +19,9 @@ import org.hl7.fhir.r5.model.Constants;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
-import org.hl7.fhir.utilities.cache.FilesystemPackageCacheManager;
-import org.hl7.fhir.utilities.cache.NpmPackage;
-import org.hl7.fhir.utilities.cache.ToolsVersion;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.hl7.fhir.utilities.npm.ToolsVersion;
 import org.hl7.fhir.utilities.json.JsonTrackingParser;
 
 public class NpmPackageManager implements IWorkerContext.ILoggingService {

--- a/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
@@ -47,7 +47,7 @@ import org.hl7.fhir.r5.model.DataRequirement;
 import org.hl7.fhir.r5.model.Enumerations;
 import org.hl7.fhir.r5.model.ParameterDefinition;
 import org.hl7.fhir.r5.model.RelatedArtifact;
-import org.hl7.fhir.utilities.cache.NpmPackage;
+import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;


### PR DESCRIPTION
Update org.hl7 dependencies to version 5.2.16

**Description**

Update org.hl7 dependencies to version 5.2.16, update package names, test

- Github Issue:  #180 
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
