### PR TITLE
Restored the ability to refresh given ig-path and root-dir.

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
+++ b/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
@@ -6,6 +6,8 @@ import org.opencds.cqf.tooling.utilities.IOUtils;
 
 public class RefreshIGParameters {
     public String ini;
+    public String rootDir;
+    public String igPath;
     public IOUtils.Encoding outputEncoding;
     public Boolean includeELM;
     public Boolean includeDependencies;

--- a/src/main/java/org/opencds/cqf/tooling/processor/BaseProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/BaseProcessor.java
@@ -1,19 +1,14 @@
 package org.opencds.cqf.tooling.processor;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import ca.uhn.fhir.context.FhirVersionEnum;
 import org.fhir.ucum.UcumService;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.elementmodel.Manager;
-import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.ImplementationGuide;
-import org.hl7.fhir.convertors.VersionConvertor_30_40;
 import org.hl7.fhir.convertors.VersionConvertor_30_50;
 import org.hl7.fhir.convertors.VersionConvertor_40_50;
-import org.hl7.fhir.r5.formats.FormatUtilities;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.utilities.IniFile;
 import org.hl7.fhir.utilities.TextFile;
@@ -74,7 +69,7 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
         }
     }
 
-    public void initialize(String rootDir, String igPath, String fhirVersion) {
+    public void initializeFromIg(String rootDir, String igPath, String fhirVersion) {
         this.rootDir = rootDir;
 
         try {
@@ -84,7 +79,16 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
             logMessage(String.format("Exceptions occurred extracting path from ig", e.getMessage()));
         }
 
-        ImplementationGuide sourceIg = loadSourceIG(igPath, fhirVersion);
+        if (fhirVersion != null) {
+            ImplementationGuide sourceIg = loadSourceIG(igPath, fhirVersion);
+        } else {
+            try {
+                ImplementationGuide sourceIg = loadSourceIG(igPath);
+            }
+            catch (Exception e) {
+                logMessage("Error Parsing File " + igPath + ": " + e.getMessage());
+            }
+        }
 
         // TODO: Perhaps we should validate the passed in fhirVersion against the fhirVersion in the IG?
 
@@ -92,7 +96,7 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
         packageId = sourceIg.getPackageId();
         canonicalBase = determineCanonical(sourceIg.getUrl());
         try {
-            packageManager = new NpmPackageManager(sourceIg, fhirVersion);
+            packageManager = new NpmPackageManager(sourceIg, this.fhirVersion);
         }
         catch (IOException e) {
             logMessage(String.format("Exceptions occurred loading npm package manager:", e.getMessage()));
@@ -102,7 +106,7 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
     /*
     Initializes from an ig.ini file in the root directory
      */
-    public void initialize(String iniFile) {
+    public void initializeFromIni(String iniFile) {
         IniFile ini = new IniFile(new File(iniFile).getAbsolutePath());
         String rootDir = Utilities.getDirectoryForFile(ini.getFileName());
         String igPath = ini.getStringProperty("IG", "ig");
@@ -111,7 +115,35 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
             logMessage("fhir-version was not specified in the ini file. Trying FHIR version 4.0.1");
             specifiedFhirVersion = "4.0.1";
         }
-        initialize(rootDir, igPath, specifiedFhirVersion);
+        try {
+            initializeFromIg(rootDir, igPath, specifiedFhirVersion);
+        }
+        catch (Exception e) {
+            logMessage(String.format("Exceptions occurred initializing refresh from ini file '%s':%s", iniFile, e.getMessage()));
+        }
+    }
+
+    private ImplementationGuide loadSourceIG(String igPath) throws Exception {
+        ImplementationGuide sourceIG = null;
+        try {
+            try {
+                sourceIg = (ImplementationGuide) org.hl7.fhir.r5.formats.FormatUtilities.loadFile(igPath);
+            } catch (Exception e) {
+                try {
+                    sourceIg = (ImplementationGuide) VersionConvertor_40_50.convertResource(org.hl7.fhir.r4.formats.FormatUtilities.loadFile(igPath));
+                } catch (Exception ex) {
+                    byte[] src = TextFile.fileToBytes(igPath);
+                    Manager.FhirFormat fmt = org.hl7.fhir.r5.formats.FormatUtilities.determineFormat(src);
+
+                    org.hl7.fhir.dstu3.formats.ParserBase parser = org.hl7.fhir.dstu3.formats.FormatUtilities.makeParser(fmt.toString());
+                    sourceIg = (ImplementationGuide) VersionConvertor_30_50.convertResource(parser.parse(src), false);
+                }
+            }
+        } catch (Exception e) {
+            throw new Exception("Error Parsing File " + igPath + ": " + e.getMessage(), e);
+        }
+
+        return sourceIg;
     }
 
     private ImplementationGuide loadSourceIG(String igPath, String specifiedFhirVersion) {

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.apache.commons.io.FilenameUtils;
 import org.hl7.fhir.utilities.Utilities;
 import org.opencds.cqf.tooling.parameter.RefreshIGParameters;
-import org.opencds.cqf.tooling.parameter.RefreshLibraryParameters;
 import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.opencds.cqf.tooling.utilities.IOUtils.Encoding;
 import org.opencds.cqf.tooling.utilities.LogUtils;
@@ -20,7 +19,10 @@ public class IGProcessor extends BaseProcessor {
     //mega ig method
     public void publishIG(RefreshIGParameters params) {
         if (params.ini != null) {
-            initialize(params.ini);
+            initializeFromIni(params.ini);
+        }
+        else {
+            initializeFromIg(params.rootDir, params.igPath, null);
         }
 
         Encoding encoding = params.outputEncoding;
@@ -74,7 +76,15 @@ public class IGProcessor extends BaseProcessor {
     public ArrayList<String> refreshedResourcesNames = new ArrayList<String>();
     public void refreshIG(RefreshIGParameters params) {
         if (params.ini != null) {
-            initialize(params.ini);
+            initializeFromIni(params.ini);
+        }
+        else {
+            try {
+                initializeFromIg(params.rootDir, params.igPath, null);
+            }
+            catch (Exception e) {
+                logMessage(String.format("Error Refreshing for File "+ params.igPath+": "+e.getMessage(), e));
+            }
         }
 
         Encoding encoding = params.outputEncoding;

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGTestProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGTestProcessor.java
@@ -159,10 +159,10 @@ public class IGTestProcessor extends BaseProcessor {
         fhirContext = params.fhirContext;
 
         if (params.ini != null) {
-            initialize(params.ini);
+            initializeFromIni(params.ini);
         }
         else {
-            initialize(params.rootDir, params.igPath, fhirContext.getVersion().toString());
+            initializeFromIg(params.rootDir, params.igPath, fhirContext.getVersion().toString());
         }
 
         CqfmSoftwareSystem testTargetSoftwareSystem =  getCqfRulerSoftwareSystem(params.fhirServerUri);

--- a/src/main/java/org/opencds/cqf/tooling/processor/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/R4LibraryProcessor.java
@@ -62,7 +62,7 @@ public class R4LibraryProcessor extends LibraryProcessor {
             } else {
                 filePath = libraryPath;
                 fileEncoding = encoding;
-            }    
+            }
             cqfmHelper.ensureCQFToolingExtensionAndDevice(library, fhirContext);
             // Issue 96
             // Passing the includeVersion here to handle not using the version number in the filename
@@ -96,7 +96,7 @@ public class R4LibraryProcessor extends LibraryProcessor {
             initialize(params.parentContext);
         }
         else {
-            initialize(params.ini);
+            initializeFromIni(params.ini);
             igCanonicalBase = params.igCanonicalBase;
             cqlContentPath = params.cqlContentPath;
         }

--- a/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/STU3LibraryProcessor.java
@@ -101,7 +101,7 @@ public class STU3LibraryProcessor extends LibraryProcessor {
             initialize(params.parentContext);
         }
         else {
-            initialize(params.ini);
+            initializeFromIni(params.ini);
             igCanonicalBase = params.igCanonicalBase;
             cqlContentPath = params.cqlContentPath;
         }

--- a/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
@@ -20,6 +20,8 @@ public class RefreshIGArgumentProcessor {
     public static final String[] OPERATION_OPTIONS = {"RefreshIG"};
 
     public static final String[] INI_OPTIONS = {"ini"};
+    public static final String[] ROOT_DIR_OPTIONS = {"root-dir"};
+    public static final String[] IG_PATH_OPTIONS = {"ip", "ig-path"};
     public static final String[] IG_OUTPUT_ENCODING = {"e", "encoding"};
     public static final String[] INCLUDE_ELM_OPTIONS = {"elm", "include-elm"};
     public static final String[] INCLUDE_DEPENDENCY_LIBRARY_OPTIONS = {"d", "include-dependencies"};
@@ -35,12 +37,16 @@ public class RefreshIGArgumentProcessor {
         OptionParser parser = new OptionParser();
 
         OptionSpecBuilder iniBuilder = parser.acceptsAll(asList(INI_OPTIONS), "Path to ig ini file");
+        OptionSpecBuilder rootDirBuilder = parser.acceptsAll(asList(ROOT_DIR_OPTIONS), "Root directory of the ig");
+        OptionSpecBuilder igPathBuilder = parser.acceptsAll(asList(IG_PATH_OPTIONS),"Path to the IG, relative to the root directory");
         OptionSpecBuilder resourcePathBuilder = parser.acceptsAll(asList(RESOURCE_PATH_OPTIONS),"Use multiple times to define multiple resource directories.");
         OptionSpecBuilder igOutputEncodingBuilder = parser.acceptsAll(asList(IG_OUTPUT_ENCODING), "If omitted, output will be generated using JSON encoding.");
         OptionSpecBuilder fhirUriBuilder = parser.acceptsAll(asList(FHIR_URI_OPTIONS),"If omitted the final bundle will not be loaded to a FHIR server.");
         OptionSpecBuilder measureToRefreshPathBuilder = parser.acceptsAll(asList(MEASURE_TO_REFRESH_PATH), "Path to Measure to refresh.");
 
         OptionSpec<String> ini = iniBuilder.withRequiredArg().describedAs("Path to the IG ini file");
+        OptionSpec<String> rootDir = rootDirBuilder.withOptionalArg().describedAs("Root directory of the IG");
+        OptionSpec<String> igPath = igPathBuilder.withRequiredArg().describedAs("Path to the IG, relative to the root directory");
         OptionSpec<String> resourcePath = resourcePathBuilder.withOptionalArg().describedAs("directory of resources");
         OptionSpec<String> igOutputEncoding = igOutputEncodingBuilder.withOptionalArg().describedAs("desired output encoding for resources");
         OptionSpec<String> measureToRefreshPath = measureToRefreshPathBuilder.withOptionalArg().describedAs("Path to Measure to refresh.");
@@ -68,6 +74,8 @@ public class RefreshIGArgumentProcessor {
         ArgUtils.ensure(OPERATION_OPTIONS[0], options);
 
         String ini = (String)options.valueOf(INI_OPTIONS[0]);
+        String rootDir = (String)options.valueOf(ROOT_DIR_OPTIONS[0]);
+        String igPath = (String)options.valueOf(IG_PATH_OPTIONS[0]);
 
         List<String> resourcePaths = ArgUtils.getOptionValues(options, RESOURCE_PATH_OPTIONS[0]);
             
@@ -93,6 +101,8 @@ public class RefreshIGArgumentProcessor {
     
         RefreshIGParameters ip = new RefreshIGParameters();
         ip.ini = ini;
+        ip.rootDir = rootDir;
+        ip.igPath = igPath;
         ip.outputEncoding = outputEncodingEnum;
         ip.includeELM = includeELM;
         ip.includeDependencies = includeDependencies;


### PR DESCRIPTION
Restored support for Refreshing given ig-path and root-dir rather than only ig.ini

**Description**

The IG Refresh operation and supporting infrastructure was modified to support the case that refresh is driven by the IG resource file rather than the ig.ini by passing in the path to the IG resource file (-ig-path) and the root directory of the IG (-root-dir). 

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [X] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [X] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
