### PR TITLE
Changed linux path "/" to File.separator to be platform independent

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
+++ b/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
@@ -167,7 +167,7 @@ public class BundleResources extends Operation {
     
     // Output
     public void output(IBaseResource resource, FhirContext context) {
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + File.separator + getOutputPath().substring(getOutputPath().lastIndexOf(File.separator)) + "-bundle." + encoding)) {
+        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + getOutputPath().substring(getOutputPath().lastIndexOf(File.separator)) + "-bundle." + encoding)) {
             writer.write(
                 encoding.equals("json")
                     ? context.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource).getBytes()

--- a/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
+++ b/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
@@ -167,7 +167,7 @@ public class BundleResources extends Operation {
     
     // Output
     public void output(IBaseResource resource, FhirContext context) {
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + getOutputPath().substring(getOutputPath().lastIndexOf("/")) + "-bundle." + encoding)) {
+        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + File.separator + getOutputPath().substring(getOutputPath().lastIndexOf(File.separator)) + "-bundle." + encoding)) {
             writer.write(
                 encoding.equals("json")
                     ? context.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource).getBytes()


### PR DESCRIPTION
<!-- give your PR a concise title describing the feature above -->

**Description**
In BundleResources.java the code to work with output path was using linux/Mac specific path delimiters ("/"). For it to work correctly on a Windows machine it needs to use File.separator. That change has only been made here, but needs to done across the project.

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [X ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [X ] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
