### PR TITLE
Fixed issues with Measure refreshing

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/Operation.java
+++ b/src/main/java/org/opencds/cqf/tooling/Operation.java
@@ -14,7 +14,7 @@ public abstract class Operation {
         File outputFile = new File(this.outputPath);
         outputFile.mkdirs();
         if (!outputFile.isDirectory()) {
-            throw new IllegalArgumentException(String.format("Specified output path is not a directory: %s"));
+            throw new IllegalArgumentException(String.format("Specified output path is not a directory: %s", outputFile));
         }
     }
 

--- a/src/main/java/org/opencds/cqf/tooling/measure/r4/RefreshR4MeasureOperation.java
+++ b/src/main/java/org/opencds/cqf/tooling/measure/r4/RefreshR4MeasureOperation.java
@@ -3,6 +3,8 @@ package org.opencds.cqf.tooling.measure.r4;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.JsonParser;
 import ca.uhn.fhir.parser.XmlParser;
+
+import org.apache.commons.io.FilenameUtils;
 import org.hl7.fhir.r4.model.Measure;
 import org.opencds.cqf.tooling.common.r4.CqfmSoftwareSystemHelper;
 import org.opencds.cqf.tooling.operation.RefreshGeneratedContentOperation;
@@ -27,7 +29,7 @@ public class RefreshR4MeasureOperation extends RefreshGeneratedContentOperation 
     }
 
     public RefreshR4MeasureOperation(String pathToMeasures) {
-        super(pathToMeasures, "-RefreshR4Measure", FhirContext.forR4(), null, pathToMeasures);
+        super(FilenameUtils.getPath(pathToMeasures), "-RefreshR4Measure", FhirContext.forR4(), null, pathToMeasures);
         jsonParser = (JsonParser)this.getFhirContext().newJsonParser();
         xmlParser = (XmlParser)this.getFhirContext().newXmlParser();
     }

--- a/src/main/java/org/opencds/cqf/tooling/processor/MeasureProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/MeasureProcessor.java
@@ -91,6 +91,10 @@ public class MeasureProcessor
                 else {
                     primaryLibrary = IOUtils.getLibraries(fhirContext).get(primaryLibraryUrl);
                 }
+                
+                if (primaryLibrary == null)
+                	throw new IllegalArgumentException(String.format("Could not resolve library url %s", primaryLibraryUrl));
+                
                 String primaryLibrarySourcePath = IOUtils.getLibraryPathMap(fhirContext).get(primaryLibrary.getIdElement().getIdPart());
                 String primaryLibraryName = ResourceUtils.getName(primaryLibrary, fhirContext);
                 if (includeVersion) {


### PR DESCRIPTION
**Description**

Added missing parameter in exception in Operation class, Changed RefreshR4MeasureOperation call to get path for file passed in, added meanigful error if library URL resolution did not work

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [X ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [X ] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
