### PR TITLE
#207: Added support for well-known model and library resolution

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/npm/NpmLibrarySourceProvider.java
+++ b/src/main/java/org/opencds/cqf/tooling/npm/NpmLibrarySourceProvider.java
@@ -31,13 +31,26 @@ public class NpmLibrarySourceProvider implements LibrarySourceProvider {
         // VersionedIdentifier.id: Name of the library
         // VersionedIdentifier.system: Namespace for the library, as a URL
         // VersionedIdentifier.version: Version of the library
+
         for (NpmPackage p : packages) {
             try {
-                InputStream s = p.loadByCanonicalVersion(identifier.getSystem()+"/Library/"+identifier.getId(), identifier.getVersion());
+                VersionedIdentifier libraryIdentifier = new VersionedIdentifier()
+                        .withId(identifier.getId())
+                        .withVersion(identifier.getVersion())
+                        .withSystem(identifier.getSystem());
+
+                if (libraryIdentifier.getSystem() == null) {
+                    libraryIdentifier.setSystem(p.canonical());
+                }
+
+                InputStream s = p.loadByCanonicalVersion(libraryIdentifier.getSystem()+"/Library/"+libraryIdentifier.getId(), libraryIdentifier.getVersion());
                 if (s != null) {
                     Library l = reader.readLibrary(s);
                     for (org.hl7.fhir.r5.model.Attachment a : l.getContent()) {
                         if (a.getContentType() != null && a.getContentType().equals("text/cql")) {
+                            if (identifier.getSystem() == null) {
+                                identifier.setSystem(libraryIdentifier.getSystem());
+                            }
                             return new ByteArrayInputStream(a.getData());
                         }
                     }

--- a/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
@@ -261,7 +261,7 @@ public class CqlProcessor {
         ModelManager modelManager = new ModelManager();
         LibraryManager libraryManager = new LibraryManager(modelManager);
         if (packages != null) {
-            modelManager.getModelInfoLoader().registerModelInfoProvider(new NpmModelInfoProvider(packages, reader, logger));
+            modelManager.getModelInfoLoader().registerModelInfoProvider(new NpmModelInfoProvider(packages, reader, logger), true);
             libraryManager.getLibrarySourceLoader().registerProvider(new NpmLibrarySourceProvider(packages, reader, logger));
         }
         libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
@@ -471,9 +471,22 @@ public class CqlProcessor {
                 .setResource(getModelInfoReferenceUrl(usingDef.getUri(), usingDef.getLocalIdentifier(), usingDef.getVersion()));
     }
 
+    /*
+    Override the referencing URL for the FHIR-ModelInfo library
+    This is required because models do not have a "namespace" in the same way that libraries do,
+    so there is no way for the UsingDefinition to have a Uri that is different than the expected URI that the
+    providers understand. I.e. model names and model URIs are one-to-one.
+     */
+    private String mapModelInfoUri(String uri, String name) {
+        if (name.equals("FHIR") && uri.equals("http://hl7.org/fhir")) {
+            return "http://fhir.org/guides/cqf/common";
+        }
+        return uri;
+    }
+
     private String getModelInfoReferenceUrl(String uri, String name, String version) {
         if (uri != null) {
-            return String.format("%s/Library/%s-ModelInfo%s", uri, name, version != null ? ("|" + version) : "");
+            return String.format("%s/Library/%s-ModelInfo%s", mapModelInfoUri(uri, name), name, version != null ? ("|" + version) : "");
         }
 
         return String.format("Library/%-ModelInfo%s", name, version != null ? ("|" + version) : "");

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.apache.commons.io.FilenameUtils;
 import org.hl7.fhir.utilities.Utilities;
 import org.opencds.cqf.tooling.parameter.RefreshIGParameters;
+import org.opencds.cqf.tooling.utilities.IGUtils;
 import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.opencds.cqf.tooling.utilities.IOUtils.Encoding;
 import org.opencds.cqf.tooling.utilities.LogUtils;
@@ -95,7 +96,13 @@ public class IGProcessor extends BaseProcessor {
         // String fhirUri = params.fhirUri;
         String measureToRefreshPath = params.measureToRefreshPath;
         ArrayList<String> resourceDirs = params.resourceDirs;
-
+        if (resourceDirs.size() == 0) {
+            try {
+                resourceDirs = IGUtils.extractResourcePaths(this.rootDir, this.sourceIg);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
         IOUtils.resourceDirectories.addAll(resourceDirs);
 
         FhirContext fhirContext = IGProcessor.getIgFhirContext(fhirVersion);

--- a/src/main/java/org/opencds/cqf/tooling/utilities/IGUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/IGUtils.java
@@ -19,6 +19,22 @@ public class IGUtils {
         return canonicalBase;
     }
 
+    public static ArrayList<String> extractResourcePaths(String rootDir, ImplementationGuide sourceIg) throws IOException {
+        ArrayList<String> result = new ArrayList<>();
+        for (ImplementationGuide.ImplementationGuideDefinitionParameterComponent p : sourceIg.getDefinition().getParameter()) {
+            if (p.getCode().equals("path-resource")) {
+                result.add(Utilities.path(rootDir, p.getValue()));
+            }
+        }
+
+        File resources = new File(Utilities.path(rootDir, "input/resources"));
+        if (resources.exists() && resources.isDirectory()) {
+            result.add(resources.getAbsolutePath());
+        }
+
+        return result;
+    }
+
     /*
     Determines the CQL content path for the given implementation guide
     @rootDir: The root directory of the implementation guide source


### PR DESCRIPTION
This change allows the providers to resolve a name without a namespace (reporting back the namespace in which resolution occurred if it did). This only matters for well-known models such as FHIR and libraries such as FHIRHelpers that have built-in providers in the translator. Rather than using the built-in providers, this change allows FHIR model info and FHIRHelpers to be resolved from an NPM package and report the correct dependency (even though they aren't resolving from the expected package of org.hl7.fhir.r4.core). There is one namespaceURI override required for FHIR, and that is because model names and uris are 1-to-1.