### PR TITLE
Added bundleId parameter to BundleResources operation

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/Main.java
+++ b/src/main/java/org/opencds/cqf/tooling/Main.java
@@ -88,12 +88,23 @@ package org.opencds.cqf.tooling;
             - Example: mvn exec:java -Dexec.args="-RefreshLibrary -ini=C:\Users\Bryn\Documents\Src\HL7\sample-ig\ig.ini -fv=fhir4 -lp=C:\Users\Bryn\Documents\Src\HL7\sample-ig\input\examples\Library-example.json"
 
         - Bundle Resources
-            - mvn exec:java -Dexec.args="[-BundleResources] [-pathtodirectory | -ptd] (-outputpath | -op) (-version | -v) "
+            - mvn exec:java -Dexec.args="[-BundleResources] [-pathtodirectory | -ptd] (-outputpath | -op) (-version | -v) (-encoding | -e) (-bundleid | -bid) "
             - Example: mvn exec:java -Dexec.args="-BundleResources -ptd=/Users/adam/Src/cqframework/opioid-cds-r4/quickstartcontent -op=/Users/adam/Src/cqframework/opioid-cds-r4/quickstartcontentbundle -v=r4"
-            - This tooling consolidates all resources from files in the 'pathtodirectory' directory into a single FHIR Bundle.
-            - Default output path: src/main/resources/org/opencds/cqf/tooling/bundle/output
-            - version = FHIR version { dstu2, stu3, r4 }
-                Default version: Dstu3
+            - This Operation consolidates all resources from files in the 'pathtodirectory' directory into a single FHIR Bundle with
+            - an ID that is the value specified in the 'bunldeid' argument and outputs that generated bundle in file format
+            - of the type specified by the 'encoding' argument to the 'outputpath' directory.
+            - Arguments:
+            -   [-pathtodirectory | -ptd] - Path to the directory containing the resource files to be consolidated into the new bundle
+            -   (-outputpath | -op) - The directory path to which the generated Bundle file should be written
+            -       Default output path: src/main/resources/org/opencds/cqf/tooling/bundle/output
+            -   (-version | -v) - FHIR version { dstu2, stu3, r4 }
+            -       Default version: stu3
+            -   (-encoding | -e) - The file format to be used for representing the resulting Bundle { json, xml }
+            -       Default Value: json
+            -   (-bundleid | -bid) - A valid FHIR ID to be used as the ID for the resulting FHIR Bundle. The Publisher
+            -       validation for Bundle requires a Bundle to have an ID. If no ID is provided, the output Bundle
+            -       will not have an ID value.
+
 
         - Bundle consolidation
             - mvn exec:java -Dexec.args="[-BundlesToBundle] [input directory path] (output encoding) (output file name) (org.opencds.cqf.qdm.output directory path)"

--- a/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
+++ b/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
@@ -62,6 +62,14 @@ public class BundleResources extends Operation {
             }
         }
 
+        if (encoding == null || encoding.isEmpty()) {
+            encoding = "json";
+        } else {
+            if (!encoding.equalsIgnoreCase("xml") && !encoding.equalsIgnoreCase("json")) {
+                throw new IllegalArgumentException(String.format("Unsupported encoding: %s. Allowed encodings { json, xml }", encoding));
+            }
+        }
+
         if (pathToDirectory == null) {
             throw new IllegalArgumentException("The path to the resource directory is required");
         }


### PR DESCRIPTION
Add an argument to the BundleResources Operation to allow for specifying an ID for the output Bundle

**Description**

The BundleResources Operation output Bundle should have an ID property value. This change adds an argument to the command line for specifying what that ID should be.

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [ ] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
