### PR TITLE
#230: Removed the FHIRHelpers resolution override, since the translat…

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/processor/DataRequirementsProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/DataRequirementsProcessor.java
@@ -71,8 +71,11 @@ public class DataRequirementsProcessor {
         requirements.reportRequirement(context.getRequirements());
         // Collect reported data requirements from each expression
         for (ExpressionDef ed : expressionDefs) {
-            ElmRequirements reportedRequirements = context.getReportedRequirements(ed);
-            requirements.reportRequirement(reportedRequirements);
+            // Just being defensive here, can happen when there are errors deserializing the measure
+            if (ed != null) {
+                ElmRequirements reportedRequirements = context.getReportedRequirements(ed);
+                requirements.reportRequirement(reportedRequirements);
+            }
         }
 
         return createLibrary(context, requirements, translatedLibrary.getIdentifier(), expressionDefs, includeLogicDefinitions);
@@ -183,7 +186,7 @@ public class DataRequirementsProcessor {
         }
 
         for (ExpressionDef def : expressionDefs) {
-            if (!(def instanceof FunctionDef) && (def.getAccessLevel() == null
+            if (def != null && !(def instanceof FunctionDef) && (def.getAccessLevel() == null
                     || def.getAccessLevel() == AccessModifier.PUBLIC)) {
                 result.add(toOutputParameterDefinition(libraryIdentifier, def));
             }
@@ -328,9 +331,9 @@ public class DataRequirementsProcessor {
         if (uri != null) {
             // The translator has no way to correctly infer the namespace of the FHIRHelpers library, since it will happily provide that source to any namespace that wants it
             // So override the declaration here so that it points back to the FHIRHelpers library in the base specification
-            if (name.equals("FHIRHelpers") && !(uri.equals("http://hl7.org/fhir") || uri.equals("http://fhir.org/guides/cqf/common"))) {
-                uri = "http://fhir.org/guides/cqf/common";
-            }
+            //if (name.equals("FHIRHelpers") && !(uri.equals("http://hl7.org/fhir") || uri.equals("http://fhir.org/guides/cqf/common"))) {
+            //    uri = "http://fhir.org/guides/cqf/common";
+            //}
             return String.format("%s/Library/%s%s", uri, name, version != null ? ("|" + version) : "");
         }
 

--- a/src/main/java/org/opencds/cqf/tooling/visitor/ElmRequirements.java
+++ b/src/main/java/org/opencds/cqf/tooling/visitor/ElmRequirements.java
@@ -28,7 +28,9 @@ public class ElmRequirements extends ElmRequirement {
             }
         }
         else {
-            requirements.add(requirement);
+            if (requirement != null) {
+                requirements.add(requirement);
+            }
         }
     }
 


### PR DESCRIPTION
…or will now correctly report the namespace from which FHIRHelpers was successfully resolved

**Description**

Removed the override of FHIRHelpers the FHIRHelpers namespace.

- Github Issue:  #230 
- [X] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [X] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
