### PR TITLE
change measureName to show path so remove works

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
@@ -136,7 +136,7 @@ public class MeasureProcessor extends BaseProcessor {
                     String bundleDestPath = FilenameUtils.concat(FilenameUtils.concat(IGProcessor.getBundlesPath(igPath), MeasureTestGroupName), measureName);
                     persistBundle(igPath, bundleDestPath, measureName, encoding, fhirContext, new ArrayList<IBaseResource>(resources.values()), fhirUri);
                     bundleFiles(igPath, bundleDestPath, measureName, measureSourcePath, primaryLibrarySourcePath, fhirContext, encoding, includeTerminology, includeDependencies, includePatientScenarios, includeVersion);
-                    bundledMeasures.add(measureName);
+                    bundledMeasures.add(measureSourcePath);
                 }
             } catch (Exception e) {
                 LogUtils.putException(measureName, e);


### PR DESCRIPTION
<!-- give your PR a concise title describing the feature above -->
Measure refresh reporting list to console was erroneously measures failing that were actually refreshing
**Description**

<!-- add a brief description of the changes here -->
Changed the code so that it uses the path to the measure for successfully refreshing measures so they will not be in failed list when complete.
- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [ x] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
