### PR TITLE
Removed cdsHooksIg processor argument; PlanDefinition processing refa…

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
+++ b/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
@@ -14,7 +14,6 @@ public class RefreshIGParameters {
     public Boolean includeTerminology;
     public Boolean includePatientScenarios;
     public Boolean versioned;
-    public Boolean cdsHooksIg;
     public String fhirUri;
     public ArrayList<String> resourceDirs;
     public Boolean conformant;

--- a/src/main/java/org/opencds/cqf/tooling/processor/CDSHooksProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/CDSHooksProcessor.java
@@ -63,8 +63,10 @@ public class CDSHooksProcessor {
         return activityDefinitionPaths;
     }
 
-    public static void addActivityDefinitionFilesToBundle(String igPath, String bundleDestPath, String libraryName, List<String> activityDefinitionPaths, FhirContext fhirContext, Encoding encoding) {
-        String bundleDestFilesPath = FilenameUtils.concat(bundleDestPath, libraryName + "-" + IGBundleProcessor.bundleFilesPathElement);
+    public static void addActivityDefinitionFilesToBundle(String igPath, String bundleDestPath, List<String> activityDefinitionPaths,
+                                                          FhirContext fhirContext, Encoding encoding) {
+        String bundleDestFilesPath =
+                FilenameUtils.concat(bundleDestPath, FilenameUtils.getBaseName(bundleDestPath) + "-" + IGBundleProcessor.bundleFilesPathElement);
         for (String path : activityDefinitionPaths) {
             IOUtils.copyFile(path, FilenameUtils.concat(bundleDestFilesPath, FilenameUtils.getName(path)));
         }

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGBundleProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGBundleProcessor.java
@@ -11,13 +11,13 @@ public class IGBundleProcessor {
     public static final String bundleFilesPathElement = "files/";    
 
     public static void bundleIg(ArrayList<String> refreshedLibraryNames, String igPath, Encoding encoding, Boolean includeELM,
-            Boolean includeDependencies, Boolean includeTerminology, Boolean includePatientScenarios, Boolean versioned, Boolean cdsHooksIg,
+            Boolean includeDependencies, Boolean includeTerminology, Boolean includePatientScenarios, Boolean versioned,
             FhirContext fhirContext, String fhirUri) {
 
         MeasureProcessor.bundleMeasures(refreshedLibraryNames, igPath, includeDependencies, includeTerminology, includePatientScenarios, versioned,
                 fhirContext, fhirUri, encoding);
 
-        PlanDefinitionProcessor.bundlePlanDefinitions(refreshedLibraryNames, igPath, includeDependencies, includeTerminology, includePatientScenarios, versioned, cdsHooksIg,
-                fhirContext, fhirUri, encoding);
+        PlanDefinitionProcessor.bundlePlanDefinitions(refreshedLibraryNames, igPath, includeDependencies, includeTerminology,
+                includePatientScenarios, versioned, fhirContext, fhirUri, encoding);
     }
 }

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -33,7 +33,6 @@ public class IGProcessor extends BaseProcessor {
         Boolean includeTerminology = params.includeTerminology;
         Boolean includePatientScenarios = params.includePatientScenarios;
         Boolean versioned = params.versioned;
-        Boolean cdsHooksIg = params.cdsHooksIg;
         String fhirUri = params.fhirUri;
         // String measureToRefreshPath = params.measureToRefreshPath;
         ArrayList<String> resourceDirs = new ArrayList<String>();
@@ -69,7 +68,7 @@ public class IGProcessor extends BaseProcessor {
         //package everything
         LogUtils.info("IGProcessor.publishIG - bundleIg");
         IGBundleProcessor.bundleIg(refreshedResourcesNames, rootDir, encoding, includeELM, includeDependencies, includeTerminology, includePatientScenarios,
-        versioned, cdsHooksIg, fhirContext, fhirUri);
+        versioned, fhirContext, fhirUri);
         //test everything
         //IGTestProcessor.testIg(IGTestParameters);
         //Publish?
@@ -110,13 +109,6 @@ public class IGProcessor extends BaseProcessor {
         FhirContext fhirContext = IGProcessor.getIgFhirContext(fhirVersion);
 
         IGProcessor.ensure(rootDir, includePatientScenarios, includeTerminology, IOUtils.resourceDirectories);
-
-        List<String> refreshedLibraryNames;
-        refreshedLibraryNames = LibraryProcessor.refreshIgLibraryContent(this, encoding, versioned, fhirContext);
-        // Only add libraries if this is a cds IG, else only measures.
-        if (params.cdsHooksIg) {
-            refreshedResourcesNames.addAll(refreshedLibraryNames);
-        }
 
         List<String> refreshedMeasureNames;
         refreshedMeasureNames = MeasureProcessor.refreshIgMeasureContent(this, encoding, versioned, fhirContext, measureToRefreshPath);
@@ -161,6 +153,7 @@ public class IGProcessor extends BaseProcessor {
     public static final String cqlLibraryPathElement = "input/pagecontent/cql/";
     public static final String libraryPathElement = "input/resources/library/";
     public static final String measurePathElement = "input/resources/measure/";
+    public static final String planDefinitionPathElement = "input/resources/plandefinition/";
     public static final String valuesetsPathElement = "input/vocabulary/valueset/";
     public static final String testCasePathElement = "input/tests/";
     public static final String devicePathElement = "input/resources/device/";
@@ -174,6 +167,7 @@ public class IGProcessor extends BaseProcessor {
             ensureDirectory(igPath, IGProcessor.cqlLibraryPathElement);
             ensureDirectory(igPath, IGProcessor.libraryPathElement);
             ensureDirectory(igPath, IGProcessor.measurePathElement);
+            ensureDirectory(igPath, IGProcessor.planDefinitionPathElement);
             ensureDirectory(igPath, IGProcessor.valuesetsPathElement);
             ensureDirectory(igPath, IGProcessor.testCasePathElement);
         }
@@ -181,6 +175,7 @@ public class IGProcessor extends BaseProcessor {
             checkForDirectory(igPath, IGProcessor.cqlLibraryPathElement);
             checkForDirectory(igPath, IGProcessor.libraryPathElement);
             checkForDirectory(igPath, IGProcessor.measurePathElement);
+            checkForDirectory(igPath, IGProcessor.planDefinitionPathElement);
             checkForDirectory(igPath, IGProcessor.valuesetsPathElement);
             checkForDirectory(igPath, IGProcessor.testCasePathElement);
         }

--- a/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.tooling.processor;
 
 import ca.uhn.fhir.context.FhirContext;
 import org.apache.commons.io.FilenameUtils;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.tooling.library.LibraryProcessor;
 import org.opencds.cqf.tooling.utilities.*;
@@ -17,77 +18,77 @@ public class PlanDefinitionProcessor {
     public static final String PlanDefinitionTestGroupName = "plandefinition";
 
     public static void bundlePlanDefinitions(ArrayList<String> refreshedLibraryNames, String igPath, Boolean includeDependencies,
-            Boolean includeTerminology, Boolean includePatientScenarios, Boolean includeVersion, Boolean cdsHooksIg, FhirContext fhirContext, String fhirUri,
-            Encoding encoding) {
-        
-        HashSet<String> planDefinitionSourcePaths = IOUtils.getPlanDefinitionPaths(fhirContext);
+                                             Boolean includeTerminology, Boolean includePatientScenarios, Boolean includeVersion,
+                                             FhirContext fhirContext, String fhirUri, Encoding encoding) {
 
-        List<String> planDefinitionPathLibraryNames = new ArrayList<String>();
-        for (String planDefinitionSourcePath : planDefinitionSourcePaths) {
-            String name = FilenameUtils.getBaseName(planDefinitionSourcePath).replace(PlanDefinitionProcessor.ResourcePrefix, "");
-
-            planDefinitionPathLibraryNames.add(name);
-        }
+        Map<String, IBaseResource> planDefinitions = IOUtils.getPlanDefinitions(fhirContext);
 
         List<String> bundledPlanDefinitions = new ArrayList<String>();
-        for (String refreshedLibraryName : refreshedLibraryNames) {
-            try {
-                if (!planDefinitionPathLibraryNames.contains(refreshedLibraryName)) {
-                    continue;
-                }
+        for (Map.Entry<String, IBaseResource> planDefinitionEntry : planDefinitions.entrySet()) {
+            String planDefinitionSourcePath = IOUtils.getPlanDefinitionPathMap(fhirContext).get(planDefinitionEntry.getKey());
 
+            // Assumption - File name matches planDefinition.name
+            String planDefinitionName = FilenameUtils.getBaseName(planDefinitionSourcePath).replace(PlanDefinitionProcessor.ResourcePrefix, "");
+            try {
                 Map<String, IBaseResource> resources = new HashMap<String, IBaseResource>();
 
-                String refreshedLibraryFileName = IOUtils.formatFileName(refreshedLibraryName, encoding, fhirContext);
-                String librarySourcePath;
-                try {
-                    librarySourcePath = IOUtils.getLibraryPathAssociatedWithCqlFileName(refreshedLibraryFileName, fhirContext);
-                } catch (Exception e) {
-                    LogUtils.putException(refreshedLibraryName, e);
-                    continue;
-                } finally {
-                    LogUtils.warn(refreshedLibraryName);
-                }
-                
-                String planDefinitionSourcePath = "";
-                for (String path : planDefinitionSourcePaths) {
-                    if (FilenameUtils.removeExtension(path).endsWith(refreshedLibraryName))
-                    {
-                        planDefinitionSourcePath = path;
-                        break;
-                    }
-                }
-
                 Boolean shouldPersist = ResourceUtils.safeAddResource(planDefinitionSourcePath, resources, fhirContext);
-                shouldPersist = shouldPersist
-                        & ResourceUtils.safeAddResource(librarySourcePath, resources, fhirContext);
+                if (!resources.containsKey(planDefinitionEntry.getKey())) {
+                    throw new IllegalArgumentException(String.format("Could not retrieve base resource for PlanDefinition %s", planDefinitionName));
+                }
+                IBaseResource planDefinition = resources.get(planDefinitionEntry.getKey());
+                String primaryLibraryUrl = ResourceUtils.getPrimaryLibraryUrl(planDefinition, fhirContext);
+                IBaseResource primaryLibrary;
+                if (primaryLibraryUrl.startsWith("http")) {
+                    primaryLibrary = IOUtils.getLibraryUrlMap(fhirContext).get(primaryLibraryUrl);
+                }
+                else {
+                    primaryLibrary = IOUtils.getLibraries(fhirContext).get(primaryLibraryUrl);
+                }
 
-                String cqlFileName = IOUtils.formatFileName(refreshedLibraryName, Encoding.CQL, fhirContext);
+                if (primaryLibrary == null)
+                    throw new IllegalArgumentException(String.format("Could not resolve library url %s", primaryLibraryUrl));
+
+                String primaryLibrarySourcePath = IOUtils.getLibraryPathMap(fhirContext).get(primaryLibrary.getIdElement().getIdPart());
+                String primaryLibraryName = ResourceUtils.getName(primaryLibrary, fhirContext);
+                if (includeVersion) {
+                    primaryLibraryName = primaryLibraryName + "-" +
+                            fhirContext.newFhirPath().evaluateFirst(primaryLibrary, "version", IBase.class).get().toString();
+                }
+
+                shouldPersist = shouldPersist
+                        & ResourceUtils.safeAddResource(primaryLibrarySourcePath, resources, fhirContext);
+
+                String cqlFileName = IOUtils.formatFileName(primaryLibraryName, Encoding.CQL, fhirContext);
                 List<String> cqlLibrarySourcePaths = IOUtils.getCqlLibraryPaths().stream()
-                    .filter(path -> path.endsWith(cqlFileName))
-                    .collect(Collectors.toList());
+                        .filter(path -> path.endsWith(cqlFileName))
+                        .collect(Collectors.toList());
                 String cqlLibrarySourcePath = (cqlLibrarySourcePaths.isEmpty()) ? null : cqlLibrarySourcePaths.get(0);
-                
+
+                if (cqlLibrarySourcePath == null) {
+                    throw new IllegalArgumentException(String.format("Could not determine CqlLibrarySource path for library %s", primaryLibraryName));
+                }
+
                 if (includeTerminology) {
                     boolean result = ValueSetsProcessor.bundleValueSets(cqlLibrarySourcePath, igPath, fhirContext, resources, encoding, includeDependencies, includeVersion);
                     if (shouldPersist && !result) {
-                        LogUtils.info("PlanDefinitions will not be bundled because ValueSet bundling failed.");
+                        LogUtils.info("PlanDefinition will not be bundled because ValueSet bundling failed.");
                     }
                     shouldPersist = shouldPersist & result;
                 }
 
                 if (includeDependencies) {
-                    boolean result = LibraryProcessor.bundleLibraryDependencies(librarySourcePath, fhirContext, resources, encoding, includeVersion);
+                    boolean result = LibraryProcessor.bundleLibraryDependencies(primaryLibrarySourcePath, fhirContext, resources, encoding, includeVersion);
                     if (shouldPersist && !result) {
-                        LogUtils.info(String.format("PlanDefinitions will not be bundled because Library Dependency bundling failed. Library: '%s'", refreshedLibraryName));
+                        LogUtils.info("PlanDefinition will not be bundled because Library Dependency bundling failed.");
                     }
                     shouldPersist = shouldPersist & result;
                 }
 
                 if (includePatientScenarios) {
-                    boolean result = TestCaseProcessor.bundleTestCases(igPath, PlanDefinitionTestGroupName, refreshedLibraryName, fhirContext, resources);
+                    boolean result = TestCaseProcessor.bundleTestCases(igPath, PlanDefinitionTestGroupName, primaryLibraryName, fhirContext, resources);
                     if (shouldPersist && !result) {
-                        LogUtils.info("PlanDefinitions will not be bundled because Test Case bundling failed.");
+                        LogUtils.info("PlanDefinition will not be bundled because Test Case bundling failed.");
                     }
                     shouldPersist = shouldPersist & result;
                 }
@@ -95,26 +96,25 @@ public class PlanDefinitionProcessor {
                 List<String> activityDefinitionPaths =  CDSHooksProcessor.bundleActivityDefinitions(planDefinitionSourcePath, fhirContext, resources, encoding, includeVersion, shouldPersist);
 
                 if (shouldPersist) {
-                    String bundleDestPath = FilenameUtils.concat(FilenameUtils.concat(IGProcessor.getBundlesPath(igPath), PlanDefinitionTestGroupName), refreshedLibraryName);
-                    persistBundle(igPath, bundleDestPath, refreshedLibraryName, encoding, fhirContext, new ArrayList<IBaseResource>(resources.values()), fhirUri);
-                    bundleFiles(igPath, bundleDestPath, refreshedLibraryName, planDefinitionSourcePath, librarySourcePath, fhirContext, encoding, includeTerminology, includeDependencies, includePatientScenarios, includeVersion);
-                    CDSHooksProcessor.addActivityDefinitionFilesToBundle(igPath, bundleDestPath, refreshedLibraryName, activityDefinitionPaths, fhirContext, encoding);
-                    if (cdsHooksIg != null && cdsHooksIg) { 
-                        CDSHooksProcessor.addRequestAndResponseFilesToBundle(igPath, bundleDestPath, refreshedLibraryName);
-                    }
-                    bundledPlanDefinitions.add(refreshedLibraryName);
+                    String bundleDestPath = FilenameUtils.concat(FilenameUtils.concat(IGProcessor.getBundlesPath(igPath), PlanDefinitionTestGroupName), planDefinitionName);
+                    persistBundle(igPath, bundleDestPath, planDefinitionName, encoding, fhirContext, new ArrayList<IBaseResource>(resources.values()), fhirUri);
+                    bundleFiles(igPath, bundleDestPath, primaryLibraryName, planDefinitionSourcePath, primaryLibrarySourcePath, fhirContext, encoding, includeTerminology, includeDependencies, includePatientScenarios, includeVersion);
+                    CDSHooksProcessor.addActivityDefinitionFilesToBundle(igPath, bundleDestPath, activityDefinitionPaths, fhirContext, encoding);
+                    bundledPlanDefinitions.add(planDefinitionSourcePath);
                 }
             } catch (Exception e) {
-                LogUtils.putException(refreshedLibraryName, e);
+                LogUtils.putException(planDefinitionName, e);
             } finally {
-                LogUtils.warn(refreshedLibraryName);
+                LogUtils.warn(planDefinitionName);
             }
         }
+
         String message = "\r\n" + bundledPlanDefinitions.size() + " PlanDefinitions successfully bundled:";
         for (String bundledPlanDefinition : bundledPlanDefinitions) {
             message += "\r\n     " + bundledPlanDefinition + " BUNDLED";
         }
 
+        List<String> planDefinitionPathLibraryNames = new ArrayList<>(IOUtils.getPlanDefinitionPaths(fhirContext));
         ArrayList<String> failedPlanDefinitions = new ArrayList<>(planDefinitionPathLibraryNames);
         planDefinitionPathLibraryNames.removeAll(bundledPlanDefinitions);
         planDefinitionPathLibraryNames.retainAll(refreshedLibraryNames);
@@ -151,7 +151,7 @@ public class PlanDefinitionProcessor {
     }
 
     private static void bundleFiles(String igPath, String bundleDestPath, String libraryName, String resourceFocusSourcePath, String librarySourcePath, FhirContext fhirContext, Encoding encoding, Boolean includeTerminology, Boolean includeDependencies, Boolean includePatientScenarios, Boolean includeVersion) {
-        String bundleDestFilesPath = FilenameUtils.concat(bundleDestPath, libraryName + "-" + IGBundleProcessor.bundleFilesPathElement);
+        String bundleDestFilesPath = FilenameUtils.concat(bundleDestPath, FilenameUtils.getBaseName(bundleDestPath) + "-" + IGBundleProcessor.bundleFilesPathElement);
         IOUtils.initializeDirectory(bundleDestFilesPath);
 
         IOUtils.copyFile(resourceFocusSourcePath, FilenameUtils.concat(bundleDestFilesPath, FilenameUtils.getName(resourceFocusSourcePath)));
@@ -165,7 +165,7 @@ public class PlanDefinitionProcessor {
         String cqlDestPath = FilenameUtils.concat(bundleDestFilesPath, cqlFileName);
         IOUtils.copyFile(cqlLibrarySourcePath, cqlDestPath);
 
-        if (includeTerminology) {  
+        if (includeTerminology) {
             try {     
                 Map<String, IBaseResource> valuesets = ResourceUtils.getDepValueSetResources(cqlLibrarySourcePath, igPath, fhirContext, includeDependencies, includeVersion);      
                 if (!valuesets.isEmpty()) {

--- a/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
@@ -28,7 +28,6 @@ public class RefreshIGArgumentProcessor {
     public static final String[] INCLUDE_TERMINOLOGY_OPTIONS = {"t", "include-terminology"};
     public static final String[] INCLUDE_PATIENT_SCENARIOS_OPTIONS = {"p", "include-patients"};
     public static final String[] VERSIONED_OPTIONS = {"v", "versioned"};
-    public static final String[] CDS_HOOKS_OPTIONS = {"cdsig", "cds-hooks-ig"};
     public static final String[] FHIR_URI_OPTIONS = {"fs", "fhir-uri"};
     public static final String[] MEASURE_TO_REFRESH_PATH = {"mtrp", "measure-to-refresh-path"};
     public static final String[] RESOURCE_PATH_OPTIONS = {"rp", "resourcepath"};
@@ -61,7 +60,6 @@ public class RefreshIGArgumentProcessor {
         parser.acceptsAll(asList(INCLUDE_TERMINOLOGY_OPTIONS),"If omitted terminology will not be packaged.");
         parser.acceptsAll(asList(INCLUDE_PATIENT_SCENARIOS_OPTIONS),"If omitted patient scenario information will not be packaged.");
         parser.acceptsAll(asList(VERSIONED_OPTIONS),"If omitted resources must be uniquely named.");
-        parser.acceptsAll(asList(CDS_HOOKS_OPTIONS),"If omitted defaulted to non cds-hooks ig.");
 
         OptionSpec<Void> help = parser.acceptsAll(asList(ArgUtils.HELP_OPTIONS), "Show this help page").forHelp();
 
@@ -91,7 +89,6 @@ public class RefreshIGArgumentProcessor {
         Boolean includeTerminology = options.has(INCLUDE_TERMINOLOGY_OPTIONS[0]);
         Boolean includePatientScenarios = options.has(INCLUDE_PATIENT_SCENARIOS_OPTIONS[0]);
         Boolean versioned = options.has(VERSIONED_OPTIONS[0]);
-        Boolean cdsHooksIg = options.has(CDS_HOOKS_OPTIONS[0]);
         String fhirUri = (String)options.valueOf(FHIR_URI_OPTIONS[0]);
         String measureToRefreshPath = (String)options.valueOf(MEASURE_TO_REFRESH_PATH[0]);
 
@@ -110,7 +107,6 @@ public class RefreshIGArgumentProcessor {
         ip.includeTerminology = includeTerminology;
         ip.includePatientScenarios = includePatientScenarios;
         ip.versioned = versioned;
-        ip.cdsHooksIg = cdsHooksIg;
         ip.resourceDirs = paths;
         ip.fhirUri = fhirUri;
         ip.measureToRefreshPath = measureToRefreshPath;

--- a/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -746,6 +746,20 @@ public class IOUtils
         }
         return planDefinitionPaths;
     }
+    private static Map<String, String> planDefinitionPathMap = new LinkedHashMap<String, String>();
+    public static Map<String, String> getPlanDefinitionPathMap(FhirContext fhirContext) {
+        if (planDefinitionPathMap.isEmpty()) {
+            setupPlanDefinitionPaths(fhirContext);
+        }
+        return planDefinitionPathMap;
+    }
+    private static Map<String, IBaseResource> planDefinitions = new LinkedHashMap<String, IBaseResource>();
+    public static Map<String, IBaseResource> getPlanDefinitions(FhirContext fhirContext) {
+        if (planDefinitions.isEmpty()) {
+            setupPlanDefinitionPaths(fhirContext);
+        }
+        return planDefinitions;
+    }
     private static void setupPlanDefinitionPaths(FhirContext fhirContext) {
         HashMap<String, IBaseResource> resources = new LinkedHashMap<String, IBaseResource>();
         for(String dir : resourceDirectories) {
@@ -762,7 +776,11 @@ public class IOUtils
             resources.entrySet().stream()
                 .filter(entry -> entry.getValue() != null)
                 .filter(entry ->  planDefinitionClassName.equals(entry.getValue().getClass().getName()))
-                .forEach(entry -> planDefinitionPaths.add(entry.getKey()));
+                .forEach(entry -> {
+                    planDefinitionPaths.add(entry.getKey());
+                    planDefinitions.put(entry.getValue().getIdElement().getIdPart(), entry.getValue());
+                    planDefinitionPathMap.put(entry.getValue().getIdElement().getIdPart(), entry.getKey());
+                });
         }
     }
 

--- a/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -586,6 +586,29 @@ public class ResourceUtils
             String parts[] = reference.split("/");
             return parts[parts.length - 1];
         }
+        else if (resource instanceof org.hl7.fhir.r5.model.PlanDefinition) {
+            org.hl7.fhir.r5.model.PlanDefinition planDefinition = (org.hl7.fhir.r5.model.PlanDefinition)resource;
+            if (!planDefinition.hasLibrary() || planDefinition.getLibrary().size() != 1) {
+                throw new IllegalArgumentException("PlanDefinition is expected to have one and only one library");
+            }
+            return planDefinition.getLibrary().get(0).getValue();
+        }
+        else if (resource instanceof org.hl7.fhir.r4.model.PlanDefinition) {
+            org.hl7.fhir.r4.model.PlanDefinition planDefinition = (org.hl7.fhir.r4.model.PlanDefinition)resource;
+            if (!planDefinition.hasLibrary() || planDefinition.getLibrary().size() != 1) {
+                throw new IllegalArgumentException("PlanDefinition is expected to have one and only one library");
+            }
+            return planDefinition.getLibrary().get(0).getValue();
+        }
+        else if (resource instanceof org.hl7.fhir.dstu3.model.PlanDefinition) {
+            org.hl7.fhir.dstu3.model.PlanDefinition planDefinition = (org.hl7.fhir.dstu3.model.PlanDefinition)resource;
+            if (!planDefinition.hasLibrary() || planDefinition.getLibrary().size() != 1) {
+                throw new IllegalArgumentException("PlanDefinition is expected to have one and only one library");
+            }
+            String reference = planDefinition.getLibrary().get(0).getReference();
+            String parts[] = reference.split("/");
+            return parts[parts.length - 1];
+        }
         else {
            throw new IllegalArgumentException("Unsupported fhir version: " + fhirContext.getVersion().getVersion().getFhirVersionString());
       }


### PR DESCRIPTION
…ctored to not depend on file names for resolution;

<!-- give your PR a concise title describing the feature above -->
Removed RefreshIG's cdsig parameter; Refactored PlanDefinition Bundling to not depending on filenames.

**Description**

Removed the cdsig parameter from the RefreshIG processor along with the logic that was using it. Also refactored the PlanDefinitionProcessor so that bundlePlanDefintions is not driven by the PlanDefinitions and not the refreshed libraries. PlanDefinition's Primary Library is now correctly resolved by the reference rather than depending on the filenames being the same. This allows for a library serving as the Primary for multiple PlanDefinitions.

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
