### PR TITLE
added fhir type to resources map creation to avoid overwrite

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
@@ -70,10 +70,10 @@ public class MeasureProcessor extends BaseProcessor {
                 Map<String, IBaseResource> resources = new HashMap<String, IBaseResource>();
 
                 Boolean shouldPersist = ResourceUtils.safeAddResource(measureSourcePath, resources, fhirContext);
-                if (!resources.containsKey("Measure-" + measureEntry.getKey())) {
+                if (!resources.containsKey("Measure/" + measureEntry.getKey())) {
                     throw new IllegalArgumentException(String.format("Could not retrieve base resource for measure %s", measureName));
                 }
-                IBaseResource measure = resources.get("Measure-" + measureEntry.getKey());
+                IBaseResource measure = resources.get("Measure/" + measureEntry.getKey());
                 String primaryLibraryUrl = ResourceUtils.getPrimaryLibraryUrl(measure, fhirContext);
                 IBaseResource primaryLibrary;
                 if (primaryLibraryUrl.startsWith("http")) {

--- a/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
@@ -70,10 +70,10 @@ public class MeasureProcessor extends BaseProcessor {
                 Map<String, IBaseResource> resources = new HashMap<String, IBaseResource>();
 
                 Boolean shouldPersist = ResourceUtils.safeAddResource(measureSourcePath, resources, fhirContext);
-                if (!resources.containsKey(measureEntry.getKey())) {
+                if (!resources.containsKey("Measure-" + measureEntry.getKey())) {
                     throw new IllegalArgumentException(String.format("Could not retrieve base resource for measure %s", measureName));
                 }
-                IBaseResource measure = resources.get(measureEntry.getKey());
+                IBaseResource measure = resources.get("Measure-" + measureEntry.getKey());
                 String primaryLibraryUrl = ResourceUtils.getPrimaryLibraryUrl(measure, fhirContext);
                 IBaseResource primaryLibrary;
                 if (primaryLibraryUrl.startsWith("http")) {

--- a/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
@@ -33,10 +33,10 @@ public class PlanDefinitionProcessor {
                 Map<String, IBaseResource> resources = new HashMap<String, IBaseResource>();
 
                 Boolean shouldPersist = ResourceUtils.safeAddResource(planDefinitionSourcePath, resources, fhirContext);
-                if (!resources.containsKey(planDefinitionEntry.getKey())) {
+                if (!resources.containsKey("PlanDefinition-" + planDefinitionEntry.getKey())) {
                     throw new IllegalArgumentException(String.format("Could not retrieve base resource for PlanDefinition %s", planDefinitionName));
                 }
-                IBaseResource planDefinition = resources.get(planDefinitionEntry.getKey());
+                IBaseResource planDefinition = resources.get("PlanDefinition-" + planDefinitionEntry.getKey());
                 String primaryLibraryUrl = ResourceUtils.getPrimaryLibraryUrl(planDefinition, fhirContext);
                 IBaseResource primaryLibrary;
                 if (primaryLibraryUrl.startsWith("http")) {

--- a/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
@@ -33,10 +33,10 @@ public class PlanDefinitionProcessor {
                 Map<String, IBaseResource> resources = new HashMap<String, IBaseResource>();
 
                 Boolean shouldPersist = ResourceUtils.safeAddResource(planDefinitionSourcePath, resources, fhirContext);
-                if (!resources.containsKey("PlanDefinition-" + planDefinitionEntry.getKey())) {
+                if (!resources.containsKey("PlanDefinition/" + planDefinitionEntry.getKey())) {
                     throw new IllegalArgumentException(String.format("Could not retrieve base resource for PlanDefinition %s", planDefinitionName));
                 }
-                IBaseResource planDefinition = resources.get("PlanDefinition-" + planDefinitionEntry.getKey());
+                IBaseResource planDefinition = resources.get("PlanDefinition/" + planDefinitionEntry.getKey());
                 String primaryLibraryUrl = ResourceUtils.getPrimaryLibraryUrl(planDefinition, fhirContext);
                 IBaseResource primaryLibrary;
                 if (primaryLibraryUrl.startsWith("http")) {

--- a/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -430,7 +430,7 @@ public class ResourceUtils
 //              if(resources.containsKey(resource.getIdElement().getIdPart())){
 //                  IBaseResource storedResource = resources.get(resource.getIdElement().getIdPart());
 //              }
-              resources.putIfAbsent(resource.fhirType() + "-" + resource.getIdElement().getIdPart(), resource);
+              resources.putIfAbsent(resource.fhirType() + "/" + resource.getIdElement().getIdPart(), resource);
           } else {
             added = false;
             LogUtils.putException(path, new Exception("Unable to add Resource: " + path));

--- a/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -427,7 +427,10 @@ public class ResourceUtils
       try {
           IBaseResource resource = IOUtils.readResource(path, fhirContext, true);
           if (resource != null) {
-            resources.putIfAbsent(resource.getIdElement().getIdPart(), resource);
+//              if(resources.containsKey(resource.getIdElement().getIdPart())){
+//                  IBaseResource storedResource = resources.get(resource.getIdElement().getIdPart());
+//              }
+              resources.putIfAbsent(resource.fhirType() + "-" + resource.getIdElement().getIdPart(), resource);
           } else {
             added = false;
             LogUtils.putException(path, new Exception("Unable to add Resource: " + path));


### PR DESCRIPTION
Primary libraries were not being added to bundle on _refresh, if the ID matched the ID of the corresponding FHIR resource (measure & planDefinition).

**Description**
ResourceUtils.safeAddResource was modified to add FHIR type to key in hashmap. Corresponding code referring to resources list was also modified to search for "FHIRType-" resourcekey.
- Github Issue:  <!-- link the relevant GitHub issue here -->
- [X ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [ X] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
