### PR TITLE
warning added for failure due to case sensitive filemap key and filen…

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
@@ -189,7 +189,7 @@ public class CqlProcessor {
         if (!fileMap.containsKey(filename)) {
             for (Map.Entry<String, CqlSourceFileInformation> entry: fileMap.entrySet()) {
                 if (filename.equalsIgnoreCase(entry.getKey())) {
-                    System.out.println(String.format("WARNING: File with a similar name but different casing was found. File found: '%s'", entry.getKey()));
+                    logger.logDebugMessage(ILoggingService.LogCategory.PROGRESS, String.format("File with a similar name but different casing was found. File found: '%s'", entry.getKey()));
                 }
             }
             return null;

--- a/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.tooling.processor;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.lang.reflect.Array;
 import java.nio.file.Paths;
 
 import java.util.ArrayList;
@@ -186,6 +187,11 @@ public class CqlProcessor {
         }
 
         if (!fileMap.containsKey(filename)) {
+            for (Map.Entry<String, CqlSourceFileInformation> entry: fileMap.entrySet()) {
+                if (filename.equalsIgnoreCase(entry.getKey())) {
+                    System.out.println(String.format("WARNING: File with a similar name but different casing was found. File found: '%s'", entry.getKey()));
+                }
+            }
             return null;
         }
 


### PR DESCRIPTION
…ame mismatch

GetFileInformation was failing silently causing an error further downstream.

**Description**
In CqlProcessor when comparing the filemap and filename if there was a different case it would return null, but caused an error downstream, with little indication of the actual error. 


- Github Issue:  <!-- link the relevant GitHub issue here -->
- [ X] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [X ] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
