### PR TITLE
fix for requiring 2 refreshes to get changes in plandef into bundles

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/library/r4/R4LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/library/r4/R4LibraryProcessor.java
@@ -78,6 +78,8 @@ public class R4LibraryProcessor extends LibraryProcessor {
                 // It would be nice for the tooling to generate library shells, we have enough information to,
                 // but the tooling gets confused about the ID and the filename and what gets written is garbage
                 IOUtils.writeResource(library, filePath, fileEncoding, fhirContext, this.versioned);
+                IOUtils.updateCachedResource(library, filePath);
+
                 String refreshedLibraryName;
                 if (this.versioned && refreshedLibrary.getVersion() != null) {
                     refreshedLibraryName = refreshedLibrary.getName() + "-" + refreshedLibrary.getVersion();

--- a/src/main/java/org/opencds/cqf/tooling/library/stu3/STU3LibraryProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/library/stu3/STU3LibraryProcessor.java
@@ -43,19 +43,23 @@ public class STU3LibraryProcessor extends LibraryProcessor {
         List<org.hl7.fhir.r5.model.Library> refreshedLibraries = super.refreshGeneratedContent(libraries);
         for (org.hl7.fhir.r5.model.Library refreshedLibrary : refreshedLibraries) {
             String filePath = fileMap.get(refreshedLibrary.getId());
-            org.hl7.fhir.dstu3.model.Library library = (org.hl7.fhir.dstu3.model.Library) VersionConvertor_30_50.convertResource(refreshedLibrary);
+            if(null != filePath) {
+                org.hl7.fhir.dstu3.model.Library library = (org.hl7.fhir.dstu3.model.Library) VersionConvertor_30_50.convertResource(refreshedLibrary);
 
-            cleanseRelatedArtifactReferences(library);
+                cleanseRelatedArtifactReferences(library);
 
-            cqfmHelper.ensureCQFToolingExtensionAndDevice(library, fhirContext);
-            IOUtils.writeResource(library, filePath, IOUtils.getEncoding(filePath), fhirContext);
-            String refreshedLibraryName;
-            if (this.versioned && refreshedLibrary.getVersion() != null) {
-                refreshedLibraryName = refreshedLibrary.getName() + "-" + refreshedLibrary.getVersion();
-            } else {
-                refreshedLibraryName = refreshedLibrary.getName();
+                cqfmHelper.ensureCQFToolingExtensionAndDevice(library, fhirContext);
+                IOUtils.writeResource(library, filePath, IOUtils.getEncoding(filePath), fhirContext);
+                IOUtils.updateCachedResource(library, filePath);
+
+                String refreshedLibraryName;
+                if (this.versioned && refreshedLibrary.getVersion() != null) {
+                    refreshedLibraryName = refreshedLibrary.getName() + "-" + refreshedLibrary.getVersion();
+                } else {
+                    refreshedLibraryName = refreshedLibrary.getName();
+                }
+                refreshedLibraryNames.add(refreshedLibraryName);
             }
-            refreshedLibraryNames.add(refreshedLibraryName);
         }
 
         return refreshedLibraryNames;

--- a/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -119,7 +119,9 @@ public class IGProcessor extends BaseProcessor {
 
         IGProcessor.ensure(rootDir, includePatientScenarios, includeTerminology, IOUtils.resourceDirectories);
 
-        libraryProcessor.refreshIgLibraryContent(this, encoding, versioned, fhirContext);
+        List<String> refreshedLibraryNames;
+        refreshedLibraryNames = libraryProcessor.refreshIgLibraryContent(this, encoding, versioned, fhirContext);
+        refreshedResourcesNames.addAll(refreshedLibraryNames);
 
         List<String> refreshedMeasureNames;
         refreshedMeasureNames = measureProcessor.refreshIgMeasureContent(this, encoding, versioned, fhirContext, measureToRefreshPath);

--- a/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -242,6 +242,13 @@ public class IOUtils
         return resource;
     }
 
+    public static void updateCachedResource(IBaseResource updatedResource, String path){
+        if(null != cachedResources.get(path)){
+            cachedResources.put(path, updatedResource);
+        }
+
+    }
+
     public static List<IBaseResource> readResources(List<String> paths, FhirContext fhirContext) 
     {
         List<IBaseResource> resources = new ArrayList<>();


### PR DESCRIPTION
Currently changes in opioid cql files requires running refresh twice to get into bundles


**Description**
Currently changes in opioid cql files requires running refresh twice to get those changes into bundles. This fix updates the cachedResources with updated refreshedLibraries (IOUtils) and collects the changed library names and adds them to refreshedResourcesNames for bundling. 

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [X ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [ X] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
