### PR TITLE
Added class target when the source structure definition is a resource…

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/ModelInfoBuilder.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/ModelInfoBuilder.java
@@ -39,7 +39,8 @@ public class ModelInfoBuilder {
             .withUrl(this.settings.url)
             .withPatientClassName(this.settings.patientClassName)
             .withPatientBirthDatePropertyName(this.settings.patientBirthDatePropertyName)
-            .withTargetQualifier(this.settings.targetQualifier);
+            .withTargetQualifier(this.settings.targetQualifier)
+            .withTargetUrl(this.settings.targetUrl);
 
         return mi;
     }

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/ModelInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/ModelInfoSettings.java
@@ -12,17 +12,19 @@ public class ModelInfoSettings {
     public String patientClassName;
     public String patientBirthDatePropertyName;
     public String targetQualifier;
+    public String targetUrl;
     //public Map<String, String> primarySearchPath = new HashMap<String, String>();
 
     public Collection<ConversionInfo> conversionInfos;
 
     public ModelInfoSettings(String name, String version, String url, String patientClassName,
-            String patientBirthDatePropertyName, String targetQualifier) {
+            String patientBirthDatePropertyName, String targetQualifier, String targetUrl) {
         this.name = name;
         this.version = version;
         this.url = url;
         this.patientClassName = patientClassName;
         this.patientBirthDatePropertyName = patientBirthDatePropertyName;
         this.targetQualifier = targetQualifier;
+        this.targetUrl = targetUrl;
     }
 }

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRModelInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRModelInfoSettings.java
@@ -9,7 +9,7 @@ import org.opencds.cqf.tooling.modelinfo.ModelInfoSettings;
 public class FHIRModelInfoSettings extends ModelInfoSettings {
 
     public FHIRModelInfoSettings(String version) {
-        super("FHIR", version, "http://hl7.org/fhir", "FHIR.Patient", "birthDate.value", "fhir");
+        super("FHIR", version, "http://hl7.org/fhir", "FHIR.Patient", "birthDate.value", "fhir", null);
         this.conversionInfos = new ArrayList<ConversionInfo>() {
             {
                 add(new ConversionInfo().withFromType("FHIR.Coding").withToType("System.Code").withFunctionName("FHIRHelpers.ToCode"));

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreClassInfoBuilder.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreClassInfoBuilder.java
@@ -46,13 +46,12 @@ public class QICoreClassInfoBuilder extends ClassInfoBuilder {
         this.buildFor("QICore", "qicore-medicationadministration");
         this.buildFor("QICore", "qicore-mednotadministered");
         this.buildFor("QICore", "qicore-medicationdispense");
-        this.buildFor("QICore", "qicore-medicationnotdispensed");
-        this.buildFor("QICore", "qicore-medicationnotrequested");
+        this.buildFor("QICore", "qicore-mednotdispensed");
+        this.buildFor("QICore", "qicore-mednotrequested");
         this.buildFor("QICore", "qicore-medicationrequest");
         this.buildFor("QICore", "qicore-medicationstatement");
         this.buildFor("QICore", "qicore-observation");
         this.buildFor("QICore", "qicore-observationnotdone");
-        this.buildFor("QICore", "qicore-patient");
         this.buildFor("QICore", "vitalspanel");
         this.buildFor("QICore", "resprate");
         this.buildFor("QICore", "heartrate");
@@ -80,6 +79,7 @@ public class QICoreClassInfoBuilder extends ClassInfoBuilder {
         this.buildFor("QICore", "qicore-specimen");
         this.buildFor("QICore", "qicore-substance");
         this.buildFor("QICore", "qicore-task");
+        this.buildFor("QICore", "qicore-tasknotdone");
         this.buildFor("QICore", "Questionnaire");
         this.buildFor("QICore", "QuestionnaireResponse");
     }

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreClassInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreClassInfoSettings.java
@@ -14,6 +14,7 @@ class QICoreClassInfoSettings extends ClassInfoSettings {
         this.modelPrefix = "QICore";
         this.helpersLibraryName = "FHIRHelpers";
         this.useCQLPrimitives = true;
+        this.createSliceElements = true;
 
         this.codeableTypes = new HashSet<String>() {
             {

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreModelInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreModelInfoSettings.java
@@ -5,6 +5,6 @@ import org.opencds.cqf.tooling.modelinfo.ModelInfoSettings;
 public class QICoreModelInfoSettings extends ModelInfoSettings {
 
     public QICoreModelInfoSettings(String version) {
-        super("QICore", version, "http://hl7.org/fhir/us/qicore", "Patient", "birthDate", "qicore");
+        super("QICore", version, "http://hl7.org/fhir/us/qicore", "Patient", "birthDate", "qicore", "http://hl7.org/fhir");
     }
 }

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/quick/QuickModelInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/quick/QuickModelInfoSettings.java
@@ -9,7 +9,7 @@ import org.opencds.cqf.tooling.modelinfo.ModelInfoSettings;
 public class QuickModelInfoSettings extends ModelInfoSettings {
 
     public QuickModelInfoSettings(String version) {
-        super("QUICK", version, "http://hl7.org/fhir/us/qicore", "QUICK.Patient", "birthDate", "quick");
+        super("QUICK", version, "http://hl7.org/fhir/us/qicore", "QUICK.Patient", "birthDate", "quick", null);
         //super("QUICK", version, "http://hl7.org/fhir", "QUICK.Patient", "birthDate", "quick");
         this.conversionInfos = new ArrayList<ConversionInfo>() {
             {

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreClassInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreClassInfoSettings.java
@@ -14,6 +14,7 @@ class USCoreClassInfoSettings extends ClassInfoSettings {
         this.modelPrefix = "USCore";
         this.helpersLibraryName = "FHIRHelpers";
         this.useCQLPrimitives = true;
+        this.createSliceElements = true;
 
         this.codeableTypes = new HashSet<String>() {
             {

--- a/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreModelInfoSettings.java
+++ b/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreModelInfoSettings.java
@@ -5,6 +5,6 @@ import org.opencds.cqf.tooling.modelinfo.ModelInfoSettings;
 public class USCoreModelInfoSettings extends ModelInfoSettings {
 
     public USCoreModelInfoSettings(String version) {
-        super("USCore", version, "http://hl7.org/fhir/us/core", "PatientProfile", "birthDate", "uscore");
+        super("USCore", version, "http://hl7.org/fhir/us/core", "PatientProfile", "birthDate", "uscore", "http://hl7.org/fhir");
     }
 }


### PR DESCRIPTION
… and has a different name than the underlying type

Fixed slice maps incorrectly including a value reference (only needed for extension slice maps)
Added targetUrl to modelInfo to support profile-based authoring
Updated QICore profile references based on QICore 4.1.0
Set createSliceSettings to true by default for USCore and QICore

