### PR TITLE
Adding a FederatingTerminologyClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,9 +288,16 @@
 
             <!-- Useful String ops -->
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+
+            <!-- Useful String ops -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.9</version>
             </dependency>
 
             <!-- BundleResources requirement -->

--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,13 @@
                 <artifactId>jopt-simple</artifactId>
                 <version>5.0.4</version>
             </dependency>
-        </dependencies>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-client</artifactId>
+            <version>5.4.2</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
         <build>
             <pluginManagement>

--- a/src/main/java/org/opencds/cqf/tooling/OperationFactory.java
+++ b/src/main/java/org/opencds/cqf/tooling/OperationFactory.java
@@ -1,7 +1,7 @@
 package org.opencds.cqf.tooling;
 
 //import org.opencds.cqf.tooling.jsonschema.SchemaGenerator;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.opencds.cqf.tooling.terminology.templateToValueSetGenerator.TemplateToValueSetGenerator;
 import org.opencds.cqf.tooling.acceleratorkit.DTProcessor;
 import org.opencds.cqf.tooling.acceleratorkit.Processor;

--- a/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/DroolPredicateToElmExpressionConverter.java
+++ b/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/DroolPredicateToElmExpressionConverter.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import com.google.common.base.Strings;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cdsframework.dto.CdsCodeDTO;
 import org.cdsframework.dto.ConditionCriteriaPredicateDTO;

--- a/src/main/java/org/opencds/cqf/tooling/measure/adapters/CqlEvaluatorMeasureTestAdapter.java
+++ b/src/main/java/org/opencds/cqf/tooling/measure/adapters/CqlEvaluatorMeasureTestAdapter.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.tooling.measure.adapters;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -28,11 +28,11 @@ public class CqlEvaluatorMeasureTestAdapter extends MeasureTestAdapter {
         // 1. Get Measure and Patient Ids from Expected
         // 2. Run evaluator with Measure, Patient, Content context
         // 3. Parse the result
-        throw new NotImplementedException();
+        throw new NotImplementedException("IMeasureReportAdapter.getActualMeasureReportAdapter");
     }
 
     @Override
     protected IMeasureReportAdapter evaluate() {
-        throw new NotImplementedException();
+        throw new NotImplementedException("IMeasureReportAdapter.evaluate()");
     }
 }

--- a/src/main/java/org/opencds/cqf/tooling/operation/PostmanCollectionOperation.java
+++ b/src/main/java/org/opencds/cqf/tooling/operation/PostmanCollectionOperation.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.MeasureReport;

--- a/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
+++ b/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
@@ -9,7 +9,7 @@ import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.opencds.cqf.tooling.Operation;
 
 import info.bliki.wiki.model.WikiModel;

--- a/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
+++ b/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.ElementDefinition;
@@ -154,7 +154,7 @@ public class QuickPageGenerator extends Operation {
                                     snapshotElement.getBinding().getStrength().toCode()
                             );
                         }
-                        description = StringEscapeUtils.escapeHtml(description) + binding;
+                        description = StringEscapeUtils.escapeHtml4(description) + binding;
 
                         String type;
                         if (element.hasType()) {
@@ -251,7 +251,7 @@ public class QuickPageGenerator extends Operation {
                 }
                 String card = Integer.toString(element.getMin()) + ".." + element.getMax();
                 String description = element.getDefinition();
-                description = StringEscapeUtils.escapeHtml(description);
+                description = StringEscapeUtils.escapeHtml3(description);
                 String type = resolveType(element);
                 if (type.contains("href=''")) {
                     type = type.replace("<a href=''>", "").replace("</a>", "");

--- a/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetMeta.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetMeta.java
@@ -3,7 +3,7 @@ package org.opencds.cqf.tooling.terminology.distributable;
 import java.time.Instant;
 import java.util.Date;
 
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;

--- a/src/main/java/org/opencds/cqf/tooling/terminology/federation/FederatingTerminologyClient.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/federation/FederatingTerminologyClient.java
@@ -1,0 +1,162 @@
+package org.opencds.cqf.tooling.terminology.federation;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.codesystems.ConceptSubsumptionOutcome;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FederatingTerminologyClient implements TerminologyService {
+
+    private FhirContext context;
+    public FederatingTerminologyClient(FhirContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("context is required");
+        }
+        this.context = context;
+    }
+
+    private List<Endpoint> terminologyEndpoints = new ArrayList<Endpoint>();
+    public FederatingTerminologyClient withTerminologyEndpoint(Endpoint endpoint) {
+        if (endpoint == null) {
+            throw new IllegalArgumentException("endpoint is required");
+        }
+        terminologyEndpoints.add(endpoint);
+        return this;
+    }
+
+    private Map<String, Endpoint> preferredTerminologyEndpoints = new HashMap<String, Endpoint>();
+    public FederatingTerminologyClient withPreferredTerminologyEndpoint(String baseUrl, Endpoint endpoint) {
+        if (baseUrl == null) {
+            throw new IllegalArgumentException("baseUrl is required");
+        }
+        if (endpoint == null) {
+            throw new IllegalArgumentException("endpoint is required");
+        }
+
+        if (!(baseUrl.endsWith("/"))) {
+            baseUrl = baseUrl + "/";
+        }
+
+        preferredTerminologyEndpoints.put(baseUrl, endpoint);
+        return this;
+    }
+
+    private FhirTerminologyClient getClient(Endpoint endpoint) {
+        // TODO: Cache terminology clients...
+        return new FhirTerminologyClient(context, endpoint);
+    }
+
+    private Endpoint getPreferredEndpoint(String url) {
+        if (url == null) {
+            throw new IllegalArgumentException("url is required");
+        }
+
+        for (Map.Entry<String, Endpoint> e : preferredTerminologyEndpoints.entrySet()) {
+            if (url.startsWith(e.getKey())) {
+                return e.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public ValueSet expand(String url) {
+        // TODO: Genericize this logic, it will be the same for all operations
+        ValueSet result = null;
+        Endpoint ep = getPreferredEndpoint(url);
+        if (ep != null) {
+            // TODO: Exception handling behavior
+            result = getClient(ep).expand(url);
+        }
+
+        if (result == null) {
+            for (Endpoint tep : terminologyEndpoints) {
+                result = getClient(tep).expand(url);
+                if (result != null) {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public ValueSet expand(String url, Iterable<String> systemVersion) {
+        ValueSet result = null;
+        Endpoint ep = getPreferredEndpoint(url);
+        if (ep != null) {
+            result = getClient(ep).expand(url, systemVersion);
+        }
+
+        if (result == null) {
+            for (Endpoint tep : terminologyEndpoints) {
+                result = getClient(tep).expand(url);
+                if (result != null) {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public Parameters lookup(String code, String systemUrl) {
+        throw new UnsupportedOperationException("lookup(code, systemUrl)");
+    }
+
+    @Override
+    public Parameters lookup(Coding coding) {
+        throw new UnsupportedOperationException("lookup(coding)");
+    }
+
+    @Override
+    public Parameters validateCodeInValueSet(String url, String code, String systemUrl, String display) {
+        throw new UnsupportedOperationException("validateCodeInValueSet(url, code, systemUrl, display)");
+    }
+
+    @Override
+    public Parameters validateCodingInValueSet(String url, Coding code) {
+        throw new UnsupportedOperationException("validateCodingInValueSet(url, code)");
+    }
+
+    @Override
+    public Parameters validateCodeableConceptInValueSet(String url, CodeableConcept concept) {
+        throw new UnsupportedOperationException("validateCodeableConceptInValueSet(url, concept)");
+    }
+
+    @Override
+    public Parameters validateCodeInCodeSystem(String url, String code, String systemUrl, String display) {
+        throw new UnsupportedOperationException("validateCodeInCodeSystem(url, code, systemUrl, display)");
+    }
+
+    @Override
+    public Parameters validateCodingInCodeSystem(String url, Coding code) {
+        throw new UnsupportedOperationException("validateCodingInCodeSystem(url, code)");
+    }
+
+    @Override
+    public Parameters validateCodeableConceptInCodeSystem(String url, CodeableConcept concept) {
+        throw new UnsupportedOperationException("validateCodeableConceptInCodeSystem(url, concept)");
+    }
+
+    @Override
+    public ConceptSubsumptionOutcome subsumes(String codeA, String codeB, String systemUrl) {
+        throw new UnsupportedOperationException("subsumes(codeA, codeB, systemUrl)");
+    }
+
+    @Override
+    public ConceptSubsumptionOutcome subsumes(Coding codeA, Coding codeB) {
+        throw new UnsupportedOperationException("subsumes(codeA, codeB)");
+    }
+}

--- a/src/main/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClient.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClient.java
@@ -1,0 +1,197 @@
+package org.opencds.cqf.tooling.terminology.federation;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.interceptor.AdditionalRequestHeadersInterceptor;
+import ca.uhn.fhir.rest.gclient.IOperation;
+import ca.uhn.fhir.rest.gclient.IOperationUntyped;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInputAndPartialOutput;
+import org.hl7.fhir.CodeableConcept;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.codesystems.ConceptSubsumptionOutcome;
+import org.opencds.cqf.tooling.utilities.CanonicalUtils;
+
+public class FhirTerminologyClient implements TerminologyService {
+
+    private IGenericClient client;
+    public FhirTerminologyClient(IGenericClient client) {
+        if (client == null) {
+            throw new IllegalArgumentException("client is required");
+        }
+
+        this.client = client;
+    }
+
+    private FhirContext context;
+    private Endpoint endpoint;
+    public FhirTerminologyClient(FhirContext context, Endpoint endpoint) {
+        if (context == null) {
+            throw new IllegalArgumentException("context is required");
+        }
+        this.context = context;
+
+        if (endpoint == null) {
+            throw new IllegalArgumentException("endpoint is required");
+        }
+        this.endpoint = endpoint;
+
+        // TODO: BasicAuthInterceptor...
+
+        this.client = context.newRestfulGenericClient(endpoint.getAddress());
+        if (endpoint.hasHeader()) {
+            AdditionalRequestHeadersInterceptor interceptor = new AdditionalRequestHeadersInterceptor();
+            for (StringType header : endpoint.getHeader()) {
+                String[] headerValues = header.getValue().split(":");
+                if (headerValues.length == 2) {
+                    interceptor.addHeaderValue(headerValues[0], headerValues[1]);
+                }
+                // TODO: Log malformed headers in the endpoint
+            }
+            client.registerInterceptor(interceptor);
+        }
+    }
+
+    private RuntimeException toException(OperationOutcome outcome) {
+        // TODO: Improve outcome to exception processing
+        if (outcome.hasIssue()) {
+            return new RuntimeException(String.format("%s.%s", outcome.getIssueFirstRep().getCode(), outcome.getIssueFirstRep().getDetails()));
+        }
+        else {
+            return new RuntimeException("Errors occurred but no details were returned");
+        }
+    }
+
+    private boolean treatCanonicalTailAsLogicalId = false;
+    public boolean getTreatCanonicalTailAsLogicalId() {
+        return this.treatCanonicalTailAsLogicalId;
+    }
+    public FhirTerminologyClient setTreatCanonicalTailAsLogicalId(boolean treatCanonicalTailAsLogicalId) {
+        this.treatCanonicalTailAsLogicalId = treatCanonicalTailAsLogicalId;
+        return this;
+    }
+
+    private Object prepareExpand(String url) {
+        String canonical = CanonicalUtils.stripVersion(url);
+        String version = CanonicalUtils.getVersion(url);
+        IOperationUntyped operation = null;
+        IOperationUntypedWithInputAndPartialOutput<Parameters> operationWithInput = null;
+        if (treatCanonicalTailAsLogicalId) {
+            operation = this.client.operation()
+                    .onInstance(String.format("ValueSet/%s", CanonicalUtils.getId(canonical)))
+                    .named("expand");
+            if (version != null) {
+                operationWithInput = operation.withParameter(Parameters.class, "valueSetVersion", new StringType().setValue(version));
+            }
+        }
+        else {
+            operation = this.client.operation()
+                    .onType(ValueSet.class)
+                    .named("expand");
+            operationWithInput = operation.withParameter(Parameters.class, "url", new StringType().setValue(canonical));
+            if (version != null) {
+                operationWithInput = operationWithInput.andParameter("valueSetVersion", new StringType().setValue(version));
+            }
+        }
+        return operationWithInput != null ? operationWithInput : operation;
+    }
+
+    private ValueSet processResultAsValueSet(Object result) {
+        if (result instanceof ValueSet) {
+            return (ValueSet)result;
+        }
+        else if (result instanceof OperationOutcome) {
+            throw toException((OperationOutcome)result);
+        }
+        else if (result == null) {
+            throw new RuntimeException("No result returned when invoking expand");
+        }
+        else {
+            throw new RuntimeException(String.format("Unexpected result type %s when invoking expand", result.getClass().getName()));
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // Probably shouldn't be doing this, but it tells me I have an unchecked cast, but it won't let me check the instance of the parameterized generic...
+    public ValueSet expand(String url) {
+        Object operationObject = prepareExpand(url);
+        IOperationUntyped operation = operationObject instanceof IOperationUntyped ? (IOperationUntyped)operationObject : null;
+        IOperationUntypedWithInputAndPartialOutput<Parameters> operationWithInput = operationObject instanceof IOperationUntypedWithInputAndPartialOutput
+                ? (IOperationUntypedWithInputAndPartialOutput<Parameters>)operationObject : null;
+
+        Object result = operationWithInput != null ? operationWithInput.execute() : operation.withNoParameters(Parameters.class).execute();
+        return processResultAsValueSet(result);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // Probably shouldn't be doing this, but it tells me I have an unchecked cast, but it won't let me check the instance of the parameterized generic...
+    public ValueSet expand(String url, Iterable<String> systemVersion) {
+        Object operationObject = prepareExpand(url);
+        IOperationUntyped operation = operationObject instanceof IOperationUntyped ? (IOperationUntyped)operationObject : null;
+        IOperationUntypedWithInputAndPartialOutput<Parameters> operationWithInput = operationObject instanceof IOperationUntypedWithInputAndPartialOutput
+                ? (IOperationUntypedWithInputAndPartialOutput<Parameters>)operationObject : null;
+        if (systemVersion != null) {
+            for (String sv : systemVersion) {
+                if (operationWithInput == null) {
+                    operationWithInput = operation.withParameter(Parameters.class, "system-version", new CanonicalType().setValue(sv));
+                }
+                else {
+                    operationWithInput = operationWithInput.andParameter("system-version", new CanonicalType().setValue(sv));
+                }
+            }
+        }
+
+        Object result = operationWithInput != null ? operationWithInput.execute() : operation.withNoParameters(Parameters.class).execute();
+        return processResultAsValueSet(result);
+    }
+
+    @Override
+    public Parameters lookup(String code, String systemUrl) {
+        throw new UnsupportedOperationException("lookup(code, systemUrl)");
+    }
+
+    @Override
+    public Parameters lookup(Coding coding) {
+        throw new UnsupportedOperationException("lookup(coding)");
+    }
+
+    @Override
+    public Parameters validateCodeInValueSet(String url, String code, String systemUrl, String display) {
+        throw new UnsupportedOperationException("validateCodeInValueSet(url, code, systemUrl, display)");
+    }
+
+    @Override
+    public Parameters validateCodingInValueSet(String url, Coding code) {
+        throw new UnsupportedOperationException("validateCodingInValueSet(url, code)");
+    }
+
+    @Override
+    public Parameters validateCodeableConceptInValueSet(String url, CodeableConcept concept) {
+        throw new UnsupportedOperationException("validateCodeableConceptInValueSet(url, concept)");
+    }
+
+    @Override
+    public Parameters validateCodeInCodeSystem(String url, String code, String systemUrl, String display) {
+        throw new UnsupportedOperationException("validateCodeInCodeSystem(url, code, systemUrl, display)");
+    }
+
+    @Override
+    public Parameters validateCodingInCodeSystem(String url, Coding code) {
+        throw new UnsupportedOperationException("validateCodingInCodeSystem(url, code)");
+    }
+
+    @Override
+    public Parameters validateCodeableConceptInCodeSystem(String url, CodeableConcept concept) {
+        throw new UnsupportedOperationException("validateCodeableConceptInCodeSystem(url, concept)");
+    }
+
+    @Override
+    public ConceptSubsumptionOutcome subsumes(String codeA, String codeB, String systemUrl) {
+        throw new UnsupportedOperationException("subsumes(codeA, codeB, systemUrl)");
+    }
+
+    @Override
+    public ConceptSubsumptionOutcome subsumes(Coding codeA, Coding codeB) {
+        throw new UnsupportedOperationException("subsumes(codeA, codeB)");
+    }
+}

--- a/src/main/java/org/opencds/cqf/tooling/terminology/federation/TerminologyService.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/federation/TerminologyService.java
@@ -1,0 +1,54 @@
+package org.opencds.cqf.tooling.terminology.federation;
+
+import org.hl7.fhir.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.codesystems.ConceptSubsumptionOutcome;
+
+/**
+ * This interface is based on the terminology services interface defined in the FHIRPath extension for FHIR:
+ * https://hl7.org/fhir/fhirpath.html#txapi
+ *
+ * However, for simplicity and coherence in the Java space, it is not a direct rendering, for example,
+ * parameters are defined explicitly, rather than encoded as a URL string
+ *
+ * In addition, for simplicity it is bound directly to FHIR R4, where most of the resources involved are normative.
+ *
+ * Also, for this interface, the overloads for client-provided resources are not implemented, on the grounds that
+ * from the perspective of a terminology client, value set and code system references are all that will be available.
+ *
+ * And lastly, in the interest of providing a simple, federated client, the interface does not use server-specific ideas,
+ * it is always based on the globally unique canonical url for value sets and code systems, and always provided using the
+ * string representation of a canonical URL, which may or may not include a pipe-separated version segment.
+ */
+public interface TerminologyService {
+    // https://hl7.org/fhir/valueset-operation-expand.html
+    // TODO: Consider activeOnly, as well as includeDraft and expansion parameters (see Measure Terminology Service in the QM IG)
+    // TODO: Consider whether to expose paging support, or make it transparent at this layer
+    ValueSet expand(String url);
+    ValueSet expand(String url, Iterable<String> systemVersion);
+
+    // https://hl7.org/fhir/codesystem-operation-lookup.html
+    // TODO: Define LookupResult class
+    Parameters lookup(String code, String systemUrl);
+    Parameters lookup(Coding coding);
+
+    // https://hl7.org/fhir/valueset-operation-validate-code.html
+    // TODO: Define ValidateResult class
+    Parameters validateCodeInValueSet(String url, String code, String systemUrl, String display);
+    Parameters validateCodingInValueSet(String url, Coding code);
+    Parameters validateCodeableConceptInValueSet(String url, CodeableConcept concept);
+
+    // https://hl7.org/fhir/codesystem-operation-validate-code.html
+    Parameters validateCodeInCodeSystem(String url, String code, String systemUrl, String display);
+    Parameters validateCodingInCodeSystem(String url, Coding code);
+    Parameters validateCodeableConceptInCodeSystem(String url, CodeableConcept concept);
+
+    // https://hl7.org/fhir/codesystem-operation-subsumes.html
+    ConceptSubsumptionOutcome subsumes(String codeA, String codeB, String systemUrl);
+    ConceptSubsumptionOutcome subsumes(Coding codeA, Coding codeB);
+
+    // https://hl7.org/fhir/conceptmap-operation-translate.html
+    // TODO: Translation support
+}

--- a/src/main/java/org/opencds/cqf/tooling/utilities/CanonicalUtils.java
+++ b/src/main/java/org/opencds/cqf/tooling/utilities/CanonicalUtils.java
@@ -27,6 +27,14 @@ public class CanonicalUtils {
         }
     }
 
+    public static String stripVersion(String url) {
+        int index = url.lastIndexOf("|");
+        if (index == -1) {
+            return url;
+        }
+        return url.substring(0, index - 1);
+    }
+
     public static String getVersion(String url) {
         int index = url.lastIndexOf("|");
         if (index == -1) {

--- a/src/test/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClientIT.java
+++ b/src/test/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClientIT.java
@@ -15,7 +15,7 @@ public class FhirTerminologyClientIT {
 
         // TODO: Need a valid APIKey here
         Endpoint vsacEndpoint = new Endpoint().setAddress("https://uat-cts.nlm.nih.gov/fhir/r4")
-                .addHeader("Authorization: Basic YXBpa2V5OmQ2MmMwOGFmLWNjNGItNGE3ZS1hNzUyLWQ4Yjk4NmM5ZWM4ZQ==");
+                .addHeader("Authorization: Basic dXNlcm5hbWU9O3Bhc3N3b3JkPUluc2VydFlvdXJBUElLZXlIZXJl");
         FhirTerminologyClient ftc = new FhirTerminologyClient(context, vsacEndpoint);
         ValueSet vs = ftc.expand("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1018");
         assertTrue(vs != null);

--- a/src/test/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClientIT.java
+++ b/src/test/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClientIT.java
@@ -1,0 +1,23 @@
+package org.opencds.cqf.tooling.terminology.federation;
+
+import static org.testng.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.Endpoint;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.testng.annotations.Test;
+
+public class FhirTerminologyClientIT {
+
+    @Test
+    public void TestDirectExpand() {
+        FhirContext context = FhirContext.forR4();
+
+        // TODO: Need a valid APIKey here
+        Endpoint vsacEndpoint = new Endpoint().setAddress("https://uat-cts.nlm.nih.gov/fhir/r4")
+                .addHeader("Authorization: Basic YXBpa2V5OmQ2MmMwOGFmLWNjNGItNGE3ZS1hNzUyLWQ4Yjk4NmM5ZWM4ZQ==");
+        FhirTerminologyClient ftc = new FhirTerminologyClient(context, vsacEndpoint);
+        ValueSet vs = ftc.expand("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1018");
+        assertTrue(vs != null);
+    }
+}

--- a/src/test/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClientIT.java
+++ b/src/test/java/org/opencds/cqf/tooling/terminology/federation/FhirTerminologyClientIT.java
@@ -15,7 +15,7 @@ public class FhirTerminologyClientIT {
 
         // TODO: Need a valid APIKey here
         Endpoint vsacEndpoint = new Endpoint().setAddress("https://uat-cts.nlm.nih.gov/fhir/r4")
-                .addHeader("Authorization: Basic dXNlcm5hbWU9O3Bhc3N3b3JkPUluc2VydFlvdXJBUElLZXlIZXJl");
+                .addHeader("Authorization: Basic YXBpa2V5OmQ2MmMwOGFmLWNjNGItNGE3ZS1hNzUyLWQ4Yjk4NmM5ZWM4ZQ==");
         FhirTerminologyClient ftc = new FhirTerminologyClient(context, vsacEndpoint);
         ValueSet vs = ftc.expand("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1018");
         assertTrue(vs != null);


### PR DESCRIPTION
Defines a TerminologyService API, and two implementations, a FhirTerminologyClient which implements the service directly against a specific endpoint, and a FederatingTerminologyClient which implements the service against a set of endpoints, possibly with preferred endpoints for specific base canonicals.