### PR TITLE
Remove CI Build Profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -647,34 +647,26 @@
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <id>ci</id>
-            <build>
-                <plugins>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,7 +24,7 @@ fi
 # Import maven settings
 cp .travis.settings.xml $HOME/.m2/settings.xml
 
-CMD="mvn deploy -DskipTests=true -Dmaven.test.skip=true -B -P ci"
+CMD="mvn deploy -DskipTests=true -Dmaven.test.skip=true -B"
 
 # Import signing key and publish a release on a tag
 if [[ ! -z "$TRAVIS_TAG" ]]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,11 +4,11 @@
 set -euxo pipefail
 bash -n "$0"
 
-CMD="mvn test integration-test -B -V -P ci"
+CMD="mvn test integration-test -B -V"
 
 if [[ ! -z "$TRAVIS_TAG" ]]
 then
-    CMD="$CMD,release"
+    CMD="$CMD -P release"
 fi
 
 eval $CMD


### PR DESCRIPTION
<!-- give your PR a concise title describing the feature above -->

**Description**

This PR removes the `ci` profile from the build. It was created to save some build time when developing locally, but in practice has created continually support issues and tripped devs up since the behavior on the CI server is slightly different than the local machine unless devs used the `-P ci` argument for mvn.

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [X] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [X] Code compiles without errors
- [X] Tests are created / updated
- [X] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
