### PR TITLE
Added Naive Parameter to EnsureExecutableValueSet Operation

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/terminology/EnsureExecutableValueSetOperation.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/EnsureExecutableValueSetOperation.java
@@ -2,16 +2,10 @@ package org.opencds.cqf.tooling.terminology;
 
 import java.io.File;
 import java.time.Instant;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.DomainResource;
-import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.MarkdownType;
-import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.*;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.utilities.IOUtils;
@@ -90,6 +84,15 @@ public class EnsureExecutableValueSetOperation extends Operation {
         if (hasSimpleCompose(valueSet) && (!valueSet.hasExpansion() || force)) {
             ValueSet.ValueSetExpansionComponent expansion = new ValueSet.ValueSetExpansionComponent();
             expansion.setTimestamp(Date.from(Instant.now()));
+
+            //Expansions via EnsureExecutableValueSet are run independent of terminology servers and should be flagged as such
+            ArrayList<ValueSet.ValueSetExpansionParameterComponent> expansionParameters = new ArrayList<>();
+            ValueSet.ValueSetExpansionParameterComponent parameterNaive = new ValueSet.ValueSetExpansionParameterComponent();
+            parameterNaive.setName("naive");
+            parameterNaive.setValue(new BooleanType(true));
+            expansionParameters.add(parameterNaive);
+            expansion.setParameter(expansionParameters);
+
             for (ValueSet.ConceptSetComponent csc : valueSet.getCompose().getInclude()) {
                 for (ValueSet.ConceptReferenceComponent crc : csc.getConcept()) {
                     expansion.addContains()

--- a/src/main/java/org/opencds/cqf/tooling/terminology/EnsureExecutableValueSetOperation.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/EnsureExecutableValueSetOperation.java
@@ -33,7 +33,7 @@ public class EnsureExecutableValueSetOperation extends Operation {
 
     @Override
     public void execute(String[] args) {
-        setOutputPath("src/main/resources/org/opencds/cqf/tooling/terminology/output"); // default
+        //setOutputPath("src/main/resources/org/opencds/cqf/tooling/terminology/output"); //default
 
         for (String arg : args) {
             if (arg.equals("-EnsureExecutableValueSet")) {
@@ -61,6 +61,9 @@ public class EnsureExecutableValueSetOperation extends Operation {
                 case "skipversion": case "sv": skipVersion = value.toLowerCase().equals("true") ? true : false; break;
                 default: throw new IllegalArgumentException("Unknown flag: " + flag);
             }
+            if (null == super.getOutputPath() || "" == getOutputPath()) {
+                setOutputPath(this.valueSetPath); //default to editing files in place
+            }
         }
 
         if (valueSetPath == null) {
@@ -73,7 +76,7 @@ public class EnsureExecutableValueSetOperation extends Operation {
                 if (resource instanceof ValueSet) {
                     ValueSet valueSet = (ValueSet)resource;
                     if ((ensureExecutable && refreshExpansion(valueSet)) || (ensureComputable && inferCompose(valueSet))) {
-                        IOUtils.writeResource(valueSet, file.getAbsolutePath(), IOUtils.Encoding.parse(encoding), getFhirContext());
+                        IOUtils.writeResource(valueSet, super.getOutputPath(), IOUtils.Encoding.parse(encoding), getFhirContext());
                     }
                 }
             }

--- a/src/test/java/org/opencds/cqf/tooling/operation/EnsureExecutableValueSetNaiveTest.java
+++ b/src/test/java/org/opencds/cqf/tooling/operation/EnsureExecutableValueSetNaiveTest.java
@@ -1,0 +1,45 @@
+package org.opencds.cqf.tooling.operation;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.apache.commons.io.FileUtils;
+import org.opencds.cqf.tooling.terminology.EnsureExecutableValueSetOperation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.hl7.fhir.r4.model.ValueSet;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EnsureExecutableValueSetNaiveTest {
+    @Test
+    public void testEnsureExecutableValueset() {
+        FhirContext fhirContext = FhirContext.forR4();
+        File output = new File("target/test/resources/org/opencds/cqf/tooling/terminology/output");
+        if (null != output.listFiles()){
+            output.delete();
+        }
+
+        EnsureExecutableValueSetOperation executableValueSetOperation = new EnsureExecutableValueSetOperation();
+        executableValueSetOperation.execute(new String[]{
+                "-EnsureExecutableValueSet",
+                "-vsp=src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual",
+                "-op=target/test/resources/org/opencds/cqf/tooling/terminology/output"
+        });
+
+        List<String> valuesetPaths = IOUtils.getFilePaths("target/test/resources/org/opencds/cqf/tooling/terminology/output", false);
+        ArrayList<ValueSet> valueSets = new ArrayList<>();
+        for (String path : valuesetPaths){
+            valueSets.add((ValueSet) IOUtils.readResource(path, fhirContext, true));
+        }
+
+        for (ValueSet valueSet : valueSets){
+            if (null == valueSet.getExpansion().getParameter().stream().filter(p -> p.getName().equals("naive")).findFirst().orElse(null)){
+                throw new IllegalArgumentException("naive parameter not set on " + valueSet.getUrl());
+            }
+        }
+    }
+}

--- a/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.117.1.7.1.292.json
+++ b/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.117.1.7.1.292.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113883.3.117.1.7.1.292",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueString": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueString": "executable"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292",
+  "identifier": [ {
+    "system": "urn:ietf:rfc:3986",
+    "value": "2.16.840.1.113883.3.117.1.7.1.292"
+  } ],
+  "version": "20170726",
+  "name": "EmergencyDepartmentVisit",
+  "title": "Emergency Department Visit",
+  "status": "active",
+  "experimental": false,
+  "publisher": "NLM",
+  "compose": {
+    "include": [ {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "concept": [ {
+        "code": "4525004",
+        "display": "Emergency department patient visit (procedure)"
+      } ]
+    } ]
+  },
+  "expansion": {
+    "timestamp": "2022-01-10T17:53:03-08:00",
+    "parameter": [ {
+      "name": "naive",
+      "valueBoolean": true
+    } ],
+    "contains": [ {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "4525004",
+      "display": "Emergency department patient visit (procedure)"
+    } ]
+  }
+}

--- a/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.122.12.1035.json
+++ b/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.122.12.1035.json
@@ -1,0 +1,64 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113883.3.464.1003.122.12.1035",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-shareablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-publishablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueCode": "shareable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueCode": "narrative"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueCode": "publishable"
+  }, {
+    "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-inclusion",
+    "valueString": "Includes only relevant concepts associated with the right side of the body. This is a grouping of SNOMED CT codes."
+  }, {
+    "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-exclusion",
+    "valueString": "Excludes concepts representing the left side of the body."
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueCode": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueCode": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-usageWarning",
+    "valueString": "This value set contains a point-in-time expansion enumerating the codes that meet the value set intent. As new versions of the code systems used by the value set are released, the contents of this expansion will need to be updated to incorporate newly defined codes that meet the value set intent. Before, and periodically during production use, the value set expansion contents SHOULD be updated. The value set expansion specifies the timestamp when the expansion was produced, SHOULD contain the parameters used for the expansion, and SHALL contain the codes that are obtained by evaluating the value set definition. If this is ONLY an executable value set, a distributable definition of the value set must be obtained to compute the updated expansion."
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035",
+  "version": "20171216",
+  "name": "Right",
+  "title": "Right",
+  "status": "active",
+  "experimental": false,
+  "publisher": "National Committee for Quality Assurance",
+  "description": "This value set contains concepts that represent the right side of the body.",
+  "purpose": "This value set may use the Quality Data Model (QDM) attribute related to Anatomical Location Site.",
+  "compose": {
+    "include": [ {
+      "system": "http://snomed.info/sct",
+      "version": "2020-09",
+      "concept": [ {
+        "code": "24028007",
+        "display": "Right (qualifier value)"
+      } ]
+    } ]
+  },
+  "expansion": {
+    "timestamp": "2022-01-10T17:53:03-08:00",
+    "parameter": [ {
+      "name": "naive",
+      "valueBoolean": true
+    } ],
+    "contains": [ {
+      "system": "http://snomed.info/sct",
+      "version": "2020-09",
+      "code": "24028007",
+      "display": "Right (qualifier value)"
+    } ]
+  }
+}

--- a/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.122.12.1036.json
+++ b/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.122.12.1036.json
@@ -1,0 +1,64 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113883.3.464.1003.122.12.1036",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-shareablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-publishablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueCode": "shareable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueCode": "narrative"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueCode": "publishable"
+  }, {
+    "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-inclusion",
+    "valueString": "Includes only relevant concepts associated with the left side of the body. This is a grouping of SNOMED CT codes."
+  }, {
+    "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-exclusion",
+    "valueString": "Excludes concepts representing the right side of the body."
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueCode": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueCode": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-usageWarning",
+    "valueString": "This value set contains a point-in-time expansion enumerating the codes that meet the value set intent. As new versions of the code systems used by the value set are released, the contents of this expansion will need to be updated to incorporate newly defined codes that meet the value set intent. Before, and periodically during production use, the value set expansion contents SHOULD be updated. The value set expansion specifies the timestamp when the expansion was produced, SHOULD contain the parameters used for the expansion, and SHALL contain the codes that are obtained by evaluating the value set definition. If this is ONLY an executable value set, a distributable definition of the value set must be obtained to compute the updated expansion."
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036",
+  "version": "20171216",
+  "name": "Left",
+  "title": "Left",
+  "status": "active",
+  "experimental": false,
+  "publisher": "National Committee for Quality Assurance",
+  "description": "This value set contains concepts that represent the left side of the body.",
+  "purpose": "This value set may use the Quality Data Model (QDM) attribute related to Anatomical Location Site.",
+  "compose": {
+    "include": [ {
+      "system": "http://snomed.info/sct",
+      "version": "2020-09",
+      "concept": [ {
+        "code": "7771000",
+        "display": "Left (qualifier value)"
+      } ]
+    } ]
+  },
+  "expansion": {
+    "timestamp": "2022-01-10T17:38:01-08:00",
+    "parameter": [ {
+      "name": "naive",
+      "valueBoolean": true
+    } ],
+    "contains": [ {
+      "system": "http://snomed.info/sct",
+      "version": "2020-09",
+      "code": "7771000",
+      "display": "Left (qualifier value)"
+    } ]
+  }
+}

--- a/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.198.12.1068.json
+++ b/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.198.12.1068.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113883.3.464.1003.198.12.1068",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueString": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueString": "executable"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068",
+  "identifier": [ {
+    "system": "urn:ietf:rfc:3986",
+    "value": "2.16.840.1.113883.3.464.1003.198.12.1068"
+  } ],
+  "version": "20171219",
+  "name": "Historyofbilateralmastectomy",
+  "title": "History of bilateral mastectomy",
+  "status": "active",
+  "experimental": false,
+  "publisher": "NLM",
+  "compose": {
+    "include": [ {
+      "system": "http://hl7.org/fhir/sid/icd-10-cm",
+      "version": "2020",
+      "concept": [ {
+        "code": "Z90.13",
+        "display": "Acquired absence of bilateral breasts and nipples"
+      } ]
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "concept": [ {
+        "code": "136071000119101",
+        "display": "History of bilateral prophylactic mastectomy (situation)"
+      }, {
+        "code": "428529004",
+        "display": "History of bilateral mastectomy (situation)"
+      } ]
+    } ]
+  },
+  "expansion": {
+    "timestamp": "2022-01-10T17:53:03-08:00",
+    "parameter": [ {
+      "name": "naive",
+      "valueBoolean": true
+    } ],
+    "contains": [ {
+      "system": "http://hl7.org/fhir/sid/icd-10-cm",
+      "version": "2020",
+      "code": "Z90.13",
+      "display": "Acquired absence of bilateral breasts and nipples"
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "136071000119101",
+      "display": "History of bilateral prophylactic mastectomy (situation)"
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "428529004",
+      "display": "History of bilateral mastectomy (situation)"
+    } ]
+  }
+}

--- a/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.198.12.1069.json
+++ b/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.198.12.1069.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113883.3.464.1003.198.12.1069",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueString": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueString": "executable"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069",
+  "identifier": [ {
+    "system": "urn:ietf:rfc:3986",
+    "value": "2.16.840.1.113883.3.464.1003.198.12.1069"
+  } ],
+  "version": "20171216",
+  "name": "StatusPostLeftMastectomy",
+  "title": "Status Post Left Mastectomy",
+  "status": "active",
+  "experimental": false,
+  "publisher": "NLM",
+  "compose": {
+    "include": [ {
+      "system": "http://hl7.org/fhir/sid/icd-10-cm",
+      "version": "2020",
+      "concept": [ {
+        "code": "Z90.12",
+        "display": "Acquired absence of left breast and nipple"
+      } ]
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "concept": [ {
+        "code": "137671000119105",
+        "display": "History of prophylactic mastectomy of left breast (situation)"
+      }, {
+        "code": "429009003",
+        "display": "History of left mastectomy (situation)"
+      } ]
+    } ]
+  },
+  "expansion": {
+    "timestamp": "2022-01-10T17:53:03-08:00",
+    "parameter": [ {
+      "name": "naive",
+      "valueBoolean": true
+    } ],
+    "contains": [ {
+      "system": "http://hl7.org/fhir/sid/icd-10-cm",
+      "version": "2020",
+      "code": "Z90.12",
+      "display": "Acquired absence of left breast and nipple"
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "137671000119105",
+      "display": "History of prophylactic mastectomy of left breast (situation)"
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "429009003",
+      "display": "History of left mastectomy (situation)"
+    } ]
+  }
+}

--- a/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.198.12.1070.json
+++ b/src/test/resources/org/opencds/cqf/tooling/testfiles/refreshIG/input/vocabulary/valueset/manual/valueset-2.16.840.1.113883.3.464.1003.198.12.1070.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113883.3.464.1003.198.12.1070",
+  "meta": {
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",
+    "valueString": "executable"
+  }, {
+    "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeRepresentationLevel",
+    "valueString": "executable"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070",
+  "identifier": [ {
+    "system": "urn:ietf:rfc:3986",
+    "value": "2.16.840.1.113883.3.464.1003.198.12.1070"
+  } ],
+  "version": "20171216",
+  "name": "StatusPostRightMastectomy",
+  "title": "Status Post Right Mastectomy",
+  "status": "active",
+  "experimental": false,
+  "publisher": "NLM",
+  "compose": {
+    "include": [ {
+      "system": "http://hl7.org/fhir/sid/icd-10-cm",
+      "version": "2020",
+      "concept": [ {
+        "code": "Z90.11",
+        "display": "Acquired absence of right breast and nipple"
+      } ]
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "concept": [ {
+        "code": "137681000119108",
+        "display": "History of prophylactic mastectomy of right breast (situation)"
+      }, {
+        "code": "429242008",
+        "display": "History of right mastectomy (situation)"
+      } ]
+    } ]
+  },
+  "expansion": {
+    "timestamp": "2022-01-10T17:53:03-08:00",
+    "parameter": [ {
+      "name": "naive",
+      "valueBoolean": true
+    } ],
+    "contains": [ {
+      "system": "http://hl7.org/fhir/sid/icd-10-cm",
+      "version": "2020",
+      "code": "Z90.11",
+      "display": "Acquired absence of right breast and nipple"
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "137681000119108",
+      "display": "History of prophylactic mastectomy of right breast (situation)"
+    }, {
+      "system": "http://snomed.info/sct",
+      "version": "2019-09",
+      "code": "429242008",
+      "display": "History of right mastectomy (situation)"
+    } ]
+  }
+}


### PR DESCRIPTION
Valuesets processed by EnsureExecutableValueSet are expanded outside a terminology server, the naive flag helps prevent the use of potentially incomplete or incorrect terminology in a production setting

- Github Issue: 
- [x] I've read the contribution guidelines
- [x] Code compiles without errors
- [x] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
