### PR TITLE
Added "synonymDesignation" argument to GenericValueSetGenerator. Rest…

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/OperationFactory.java
+++ b/src/main/java/org/opencds/cqf/tooling/OperationFactory.java
@@ -78,7 +78,7 @@ class OperationFactory {
             case "BundlesToBundle":
                 throw new NotImplementedException("BundlesToBundle");
             case "BundleToResources":
-                throw new NotImplementedException("BundleToResources");
+                return new BundleToResources();
             case "ExtractMatBundle":
             	return new ExtractMatBundleOperation();
             case "GenerateMIs":

--- a/src/main/java/org/opencds/cqf/tooling/terminology/GenericValueSetGenerator.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/GenericValueSetGenerator.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.dstu3.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
@@ -77,6 +78,11 @@ public class GenericValueSetGenerator extends Operation {
     private int systemRow = 1;
     private int systemCol = 2;
 
+    private boolean hasSynonymDesignation = false;
+    private int synonymDesignationSheet = 1; // -synonymdesignation (-syn) = sheet#:row#:column#
+    private int synonymDesignationRow = 1;
+    private int synonymDesignationCol = 4;
+
     private boolean hasStaticSystem = false;
     private int staticSystemSheet = -1; // -staticsystem (-ss) = sheet#:row#:column#
     private int staticSystemRow = -1;
@@ -94,10 +100,7 @@ public class GenericValueSetGenerator extends Operation {
 
     private Map<Integer, org.opencds.cqf.tooling.terminology.ValueSet> codesBySystem = new HashMap<>();
 
-    @Override
-    public void execute(String[] args) {
-        setOutputPath("src/main/resources/org/opencds/cqf/tooling/terminology/output"); // default
-
+    private void processArguments(String[] args) {
         for (String arg : args) {
             if (arg.equals("-XlsxToValueSet")) {
                 continue;
@@ -197,6 +200,13 @@ public class GenericValueSetGenerator extends Operation {
                         systemRow = Integer.valueOf(sheetRowCol[1]);
                         systemCol = Integer.valueOf(sheetRowCol[2]);
                         break;
+                    case "synonymdesignation": case "syn":
+                        hasSynonymDesignation = true;
+                        if (sheetRowCol == null) break;
+                        synonymDesignationSheet = Integer.valueOf(sheetRowCol[0]);
+                        synonymDesignationRow = Integer.valueOf(sheetRowCol[1]);
+                        synonymDesignationCol = Integer.valueOf(sheetRowCol[2]);
+                        break;
                     case "staticsystem": case "ss":
                         if (hasSystem) {
                             throw new IllegalArgumentException("Cannot have both system and staticsystem flags set");
@@ -255,6 +265,13 @@ public class GenericValueSetGenerator extends Operation {
         if (!hasSystem && !hasStaticSystem) {
             throw new IllegalArgumentException("-system or -staticsystem flag must be specified");
         }
+    }
+
+    @Override
+    public void execute(String[] args) {
+        setOutputPath("src/main/resources/org/opencds/cqf/tooling/terminology/output"); // default
+
+        processArguments(args);
 
         Workbook workbook = SpreadsheetHelper.getWorkbook(pathToSpreadsheet);
         ValueSet vs = new ValueSet();
@@ -297,6 +314,7 @@ public class GenericValueSetGenerator extends Operation {
         Iterator<Row> codeIterator = workbook.getSheetAt(codeSheet).rowIterator();
         Iterator<Row> displayIterator = hasDisplay ? workbook.getSheetAt(displaySheet).rowIterator() : null;
         Iterator<Row> systemIterator = hasSystem ? workbook.getSheetAt(systemSheet).rowIterator() : null;
+        Iterator<Row> synonymDesignationIterator = hasSynonymDesignation ? workbook.getSheetAt(synonymDesignationSheet).rowIterator() : null;
         String system = hasStaticSystem
                 ? SpreadsheetHelper.getCellAsString(workbook.getSheetAt(staticSystemSheet).getRow(staticSystemRow).getCell(staticSystemCol))
                 : null;
@@ -309,6 +327,10 @@ public class GenericValueSetGenerator extends Operation {
             Row row = codeIterator.next();
             if (row.getRowNum() < codeRow) {
                 continue;
+            }
+
+            if (getNextValue(codeIterator, row.getRowNum(), 0) == null) {
+                break;
             }
 
             if (systemIterator != null) {
@@ -340,7 +362,21 @@ public class GenericValueSetGenerator extends Operation {
                 display = getNextValue(displayIterator, displayRow, displayCol);
             }
 
+            String synonym = null;
+            if (synonymDesignationIterator != null) {
+                synonym = getNextValue(synonymDesignationIterator, synonymDesignationRow, synonymDesignationCol);
+            }
+
             ValueSet.ConceptReferenceComponent concept = new ValueSet.ConceptReferenceComponent().setCode(code).setDisplay(display);
+            if (synonym != null && !synonym.isEmpty()) {
+                Coding synonymUseCoding = new Coding();
+                synonymUseCoding.setSystem("http://snomed.info/sct");
+                synonymUseCoding.setCode("synonym");
+                synonymUseCoding.setDisplay("Synonym");
+
+                ValueSet.ConceptReferenceDesignationComponent conceptDesignation = new ValueSet.ConceptReferenceDesignationComponent().setUse(synonymUseCoding).setValue(synonym);
+                concept.getDesignation().add(conceptDesignation);
+            }
             codesBySystem.get(hash).addCode(concept);
         }
     }

--- a/src/main/java/org/opencds/cqf/tooling/terminology/GenericValueSetGenerator.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/GenericValueSetGenerator.java
@@ -329,16 +329,19 @@ public class GenericValueSetGenerator extends Operation {
                 continue;
             }
 
-            if (getNextValue(codeIterator, row.getRowNum(), 0) == null) {
+            String code = SpreadsheetHelper.getCellAsString(row.getCell(codeCol));
+            if (code == null || code.isEmpty()) {
                 break;
             }
 
             if (systemIterator != null) {
                 system = getNextValue(systemIterator, systemRow, systemCol);
             }
+            
             if (system == null) {
                 throw new IllegalArgumentException("System not provided");
             }
+
             try {
                 system = system.startsWith("http") ? system : CodeSystemLookupDictionary.getUrlFromName(system);
             } catch (IllegalArgumentException e) {
@@ -354,8 +357,6 @@ public class GenericValueSetGenerator extends Operation {
             if (!codesBySystem.containsKey(hash)) {
                 codesBySystem.put(hash, new org.opencds.cqf.tooling.terminology.ValueSet().setSystem(system).setVersion(version));
             }
-
-            String code = SpreadsheetHelper.getCellAsString(row.getCell(codeCol));
 
             String display = null;
             if (displayIterator != null) {


### PR DESCRIPTION
…ored BundleToResources Operation

Added the synonymDesignation argument to the GenericValueSetGenerator. 

The synonymDesignation argument allows for the specification of where in the source spreadsheet a synonym value to be used for a display for codes can be found. If specified and a value is found, this will be added in the compose.include.concept.designation with a use of "synonym" (SNOMED code) and a value that is the value from the spreadsheet cell.

Also fixed a bug in the interation - the codeIteration was skipping every other row as a result of calling getNextValue to check for a value - that increments the iterator. 

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
