### PR TITLE
Fix bug in defaulting output folder for ValueSet operations

### DIFF
--- a/src/main/java/org/opencds/cqf/tooling/Operation.java
+++ b/src/main/java/org/opencds/cqf/tooling/Operation.java
@@ -6,7 +6,7 @@ import java.nio.file.Paths;
 
 public abstract class Operation {
 
-    private String outputPath = Paths.get("src/main/resources/org/opencds/cqf/tooling/terminology/output").toAbsolutePath().toString();
+    private String outputPath;
     protected String getOutputPath() {
         return outputPath;
     }

--- a/src/main/java/org/opencds/cqf/tooling/terminology/EnsureExecutableValueSetOperation.java
+++ b/src/main/java/org/opencds/cqf/tooling/terminology/EnsureExecutableValueSetOperation.java
@@ -2,10 +2,18 @@ package org.opencds.cqf.tooling.terminology;
 
 import java.io.File;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.MarkdownType;
+import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.utilities.IOUtils;
@@ -61,7 +69,7 @@ public class EnsureExecutableValueSetOperation extends Operation {
                 case "skipversion": case "sv": skipVersion = value.toLowerCase().equals("true") ? true : false; break;
                 default: throw new IllegalArgumentException("Unknown flag: " + flag);
             }
-            if (null == super.getOutputPath() || "" == getOutputPath()) {
+            if (null == getOutputPath() || getOutputPath().equals("")) {
                 setOutputPath(this.valueSetPath); //default to editing files in place
             }
         }


### PR DESCRIPTION
**Description**

The ValueSet operations defaulted to a project specific path and the intention to default to the input path had a bug.
The implementation was updated to remove the project specific path default and fix the bug to default the output path to the input path.

- Github Issue:  None
- [x] I've read the contribution guidelines 
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
