### PR TITLE
Only propagate version to grouping valuesets, not leaves.

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
@@ -390,7 +390,6 @@ public class ErsdTransformer extends Operation {
                 )
             );
         }
-        res.setVersion(this.version);
 
         Extension stewardExtension = res.getExtensionByUrl(valueSetStewardExtensionUrl);
         if (stewardExtension != null && stewardExtension.hasValue()) {
@@ -411,6 +410,7 @@ public class ErsdTransformer extends Operation {
         grouperUrls.add("http://hl7.org/fhir/us/ecr/ValueSet/sdtc");
         String url = res.getUrl();
         if (grouperUrls.contains(url)) {
+            res.setVersion(this.version);
             res.setPublisher(PUBLISHER);
 
             ValueSet.ValueSetComposeComponent compose = res.getCompose();


### PR DESCRIPTION
eRSD Transformer only propagates the RCTC version to the grouper value sets, not leaves.

**Description**

eRSD Transformer only propagates the RCTC version to the grouper value sets, not leaves.

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
