### PR TITLE
eRSDTransformer experimental fix, PlanDef reference removal

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
@@ -212,7 +212,7 @@ public class ErsdTransformer extends Operation {
         specificationLibrary.setDescription(
                 "Defines the asset-collection library containing the US Public Health specification assets.");
         specificationLibrary.setStatus(PublicationStatus.ACTIVE);
-        specificationLibrary.setExperimental(true);
+        specificationLibrary.setExperimental(false);
         specificationLibrary.setPublisher(PUBLISHER);
         specificationLibrary.setUrl("http://ersd.aimsplatform.org/fhir/Library/SpecificationLibrary");
         specificationLibrary.setType(new CodeableConcept(
@@ -276,7 +276,7 @@ public class ErsdTransformer extends Operation {
         // });
         // res.setVersion(this.version);
         // res.setPublisher(PUBLISHER);
-        // res.setExperimental(true);
+        // res.setExperimental(false);
         // res.setDescription("Example Description");
         return null;
     }
@@ -365,14 +365,7 @@ public class ErsdTransformer extends Operation {
 
         // Update Grouping ValueSet references (in useContexts) to PlanDefinition
         List<UsageContext> useContexts = res.getUseContext();
-
-        if (v2PlanDefinition != null) {
-            useContexts.stream().forEach(uc -> {
-                if (uc.hasValueReference() && uc.getValueReference().hasReference() && uc.getValueReference().getReference().contains("skeleton")) {
-                    uc.setValue(new Reference(v2PlanDefinition.getId()));
-                }
-            });
-        }
+        res.getUseContext().removeIf(uc -> uc.hasValueReference() && uc.getValueReference().hasReference() && uc.getValueReference().getReference().contains("skeleton"));
 
         boolean hasPriorityUseContext = false;
         for (UsageContext uc : useContexts) {
@@ -431,7 +424,7 @@ public class ErsdTransformer extends Operation {
             compose.getInclude().remove(include);
         }
 
-        res.setExperimental(true);
+        res.setExperimental(false);
         return null;
     }
 


### PR DESCRIPTION
Updates to eRSDTransformer to set experimental element false and strip reference to PlanDefinition from Groupers

**Description**
Updates to eRSDTransformer to set experimental element false and strip reference to PlanDefinition from Groupers

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
