### PR TITLE
Added code to set the id of the Library and the Measure to the name

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/ExtractMatBundleOperation.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/ExtractMatBundleOperation.java
@@ -175,7 +175,10 @@ public class ExtractMatBundleOperation extends Operation {
         		if (theResource instanceof org.hl7.fhir.dstu3.model.Library) {
         			org.hl7.fhir.dstu3.model.Library theLibrary = (org.hl7.fhir.dstu3.model.Library)theResource;
         			resourceName = theLibrary.getName();
-        			
+
+					// Set the id to the name regardless of what it is now for publishing
+					theLibrary.setId(resourceName);
+
         			// Forcing the encoding to JSON here to make everything the same in input directory
         			ResourceUtils.outputResourceByName(theResource, "json", context,
         					newLibraryDirectory.toString(), resourceName);
@@ -185,7 +188,11 @@ public class ExtractMatBundleOperation extends Operation {
         			extractStu3CQL(theLibrary, cqlFilename);
         		}
         		else if (theResource instanceof org.hl7.fhir.dstu3.model.Measure) {
-        			resourceName = ((org.hl7.fhir.dstu3.model.Measure)theResource).getName();
+					org.hl7.fhir.dstu3.model.Measure theMeasure = (org.hl7.fhir.dstu3.model.Measure)theResource;
+					resourceName = theMeasure.getName();
+
+					// Set the id to the name regardless of what it is now for publishing
+					theMeasure.setId(resourceName);
         			
         			// Forcing the encoding to JSON here to make everything the same in input directory
         			ResourceUtils.outputResourceByName(theResource, "json", context,
@@ -196,6 +203,9 @@ public class ExtractMatBundleOperation extends Operation {
         		if (theResource instanceof org.hl7.fhir.r4.model.Library) {
         			org.hl7.fhir.r4.model.Library theLibrary = (org.hl7.fhir.r4.model.Library)theResource;
         			resourceName = theLibrary.getName();
+
+					// Set the id to the name regardless of what it is now for publishing
+					theLibrary.setId(resourceName);
         			
         			// Forcing the encoding to JSON here to make everything the same in input directory
         			ResourceUtils.outputResourceByName(theResource, "json", context,
@@ -206,8 +216,12 @@ public class ExtractMatBundleOperation extends Operation {
         			extractR4CQL(theLibrary, cqlFilename);
         		}
         		else if (theResource instanceof org.hl7.fhir.r4.model.Measure) {
-        			resourceName = ((org.hl7.fhir.r4.model.Measure)theResource).getName();
-        			
+					org.hl7.fhir.r4.model.Measure theMeasure = (org.hl7.fhir.r4.model.Measure)theResource;
+        			resourceName = theMeasure.getName();
+
+					// Set the id to the name regardless of what it is now for publishing
+					theMeasure.setId(resourceName);
+
         			// Forcing the encoding to JSON here to make everything the same in input directory
         			ResourceUtils.outputResourceByName(theResource, "json", context,
         					newMeasureDirectory.toString(), resourceName);


### PR DESCRIPTION
Added code to set the id of the Library and the Measure to the name or publishing reasons

Since for publishing we need the id of the resources to match the canonical added code to ensure that the id gets set during the extraction regardless of how it is set in the bundle

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [ ] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [ ] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
