### PR TITLE
Set Name element of Module Definition Library in Effective Data Requirements Calculation

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureRefreshProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureRefreshProcessor.java
@@ -78,8 +78,11 @@ public class MeasureRefreshProcessor {
     private void setEffectiveDataRequirements(Measure measureToUse, Library moduleDefinitionLibrary) {
     	
     	moduleDefinitionLibrary.setId("effective-data-requirements");
-    	
-    	int delIndex = -1;
+
+        // Name should be usable as machine-processable identifier
+        moduleDefinitionLibrary.setName("EffectiveDataRequirements");
+
+        int delIndex = -1;
     	for (Resource res : measureToUse.getContained()) {
     		if (res instanceof Library && ((Library)res).getId().equalsIgnoreCase("effective-data-requirements")) {
     			delIndex = measureToUse.getContained().indexOf(res);

--- a/tooling/src/test/java/org/opencds/cqf/tooling/utilities/ECQMCreatorIT.java
+++ b/tooling/src/test/java/org/opencds/cqf/tooling/utilities/ECQMCreatorIT.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 
@@ -650,6 +651,7 @@ public class ECQMCreatorIT {
         try {
             Measure measure = refreshMeasure("CompositeMeasures/cql/BCSComponent.cql", "CompositeMeasures/resources/BCSComponent-v0-0-001-FHIR-4-0-1.xml");
             assertTrue(null != measure);
+            assertEquals("EffectiveDataRequirements", ((Library) measure.getContained().get(0)).getName());
             logger.debug(measureToString(measure));
         } catch (IOException ioException) {
             ioException.printStackTrace();
@@ -661,6 +663,7 @@ public class ECQMCreatorIT {
         try {
             Measure measure = refreshMeasure("CompositeMeasures/cql/CCSComponent.cql", "CompositeMeasures/resources/CCSComponent-v0-0-001-FHIR-4-0-1.xml");
             assertTrue(null != measure);
+            assertEquals("EffectiveDataRequirements", ((Library) measure.getContained().get(0)).getName());
             logger.debug(measureToString(measure));
         } catch (IOException ioException) {
             ioException.printStackTrace();
@@ -672,6 +675,7 @@ public class ECQMCreatorIT {
         try {
             Measure measure = refreshMeasure("CompositeMeasures/cql/HBPComponent.cql", "CompositeMeasures/resources/HBPComponent-v0-0-001-FHIR-4-0-1.xml");
             assertTrue(null != measure);
+            assertEquals("EffectiveDataRequirements", ((Library) measure.getContained().get(0)).getName());
             logger.debug(measureToString(measure));
         } catch (IOException ioException) {
             ioException.printStackTrace();
@@ -683,6 +687,7 @@ public class ECQMCreatorIT {
         try {
             Measure measure = refreshMeasure("CompositeMeasures/cql/PVSComponent.cql", "CompositeMeasures/resources/PVSComponent-v0-0-001-FHIR-4-0-1.xml");
             assertTrue(null != measure);
+            assertEquals("EffectiveDataRequirements", ((Library) measure.getContained().get(0)).getName());
             logger.debug(measureToString(measure));
         } catch (IOException ioException) {
             ioException.printStackTrace();
@@ -694,6 +699,7 @@ public class ECQMCreatorIT {
         try {
             Measure measure = refreshMeasure("CompositeMeasures/cql/TSCComponent.cql", "CompositeMeasures/resources/TSCComponent-v0-0-001-FHIR-4-0-1.xml");
             assertTrue(null != measure);
+            assertEquals("EffectiveDataRequirements", ((Library) measure.getContained().get(0)).getName());
             logger.debug(measureToString(measure));
         } catch (IOException ioException) {
             ioException.printStackTrace();
@@ -706,6 +712,7 @@ public class ECQMCreatorIT {
         try {
             Measure measure = refreshMeasure("CompositeMeasures/cql/EXM124-9.0.000.cql", "/ecqm/resources/measure-EXM124-9.0.000.json");
             assertTrue(null != measure);
+            assertEquals("EffectiveDataRequirements", ((Library) measure.getContained().get(0)).getName());
             logger.debug(measureToString(measure));
         } catch (IOException ioException) {
             ioException.printStackTrace();


### PR DESCRIPTION
**Description**

The result of an effective data requirements calculation is a Library resource which is subject to the lib-0 constraint on name defined in the base resource requiring that the name be usable as a machine-processable identifier.

This Change sets the "name" element of the resulting module definition library to "EffectiveDataRequirements" to satisfy this constraint.

Added assertion to tests to ensure Name is set.


- Github Issue:  https://github.com/cqframework/cqf-tooling/issues/348
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
