### PR TITLE
Replace use of System.out/System.err with SLF4J Logging

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/DTProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/DTProcessor.java
@@ -35,8 +35,13 @@ import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DTProcessor extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private String pathToSpreadsheet; // -pathtospreadsheet (-pts)
     private String encoding = "json"; // -encoding (-e)
 
@@ -125,10 +130,10 @@ public class DTProcessor extends Operation {
     private void processDecisionTablePage(Workbook workbook, String page) {
         Sheet sheet = workbook.getSheet(page);
         if (sheet == null) {
-            System.out.println(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
+            logger.info(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
         }
         else {
-            System.out.println(String.format("Processing Sheet %s.", page));
+            logger.info(String.format("Processing Sheet %s.", page));
             processDecisionTableSheet(workbook, sheet);
         }
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/Processor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/Processor.java
@@ -42,11 +42,15 @@ import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by Bryn on 8/18/2019.
  */
 public class Processor extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
     private String pathToSpreadsheet; // -pathtospreadsheet (-pts)
     private String encoding = "json"; // -encoding (-e)
     private String scopes; // -scopes (-s)
@@ -906,7 +910,7 @@ public class Processor extends Operation {
     private void processDataElementPage(Workbook workbook, String page, String scope) {
         Sheet sheet = workbook.getSheet(page);
         if (sheet == null) {
-            System.out.println(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
+            logger.info(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
         }
 
         questionnaireItemLinkIdCounter = 1;
@@ -1143,7 +1147,7 @@ public class Processor extends Operation {
         }
 
         if (typeString == null || typeString.isEmpty()) {
-            System.out.println(String.format("Could not determine type for Data Element: %s.", dataElement.getDataElementLabel()));
+            logger.info(String.format("Could not determine type for Data Element: %s.", dataElement.getDataElementLabel()));
             return type;
         }
 
@@ -1188,7 +1192,7 @@ public class Processor extends Operation {
                 type = Questionnaire.QuestionnaireItemType.QUANTITY;
                 break;
             default:
-                System.out.println(String.format("Questionnaire Item Type not mapped: %s.", typeString));
+                logger.info(String.format("Questionnaire Item Type not mapped: %s.", typeString));
         }
 
         return type;
@@ -1204,7 +1208,7 @@ public class Processor extends Operation {
         if (questionnaireItemType != null) {
             questionnaireItem.setType(questionnaireItemType);
         } else {
-            System.out.println(String.format("Unable to determine questionnaire item type for item '%s'.", dataElement.getDataElementLabel()));
+            logger.info(String.format("Unable to determine questionnaire item type for item '%s'.", dataElement.getDataElementLabel()));
         }
 
         questionnaire.getItem().add(questionnaireItem);
@@ -2036,7 +2040,7 @@ public class Processor extends Operation {
             ensureChoicesDataElement(element, sd);
 
         } catch (Exception e) {
-            System.out.println(String.format("Error ensuring element for '%s'. Error: %s ", element.getLabel(), e));
+            logger.error(String.format("Error ensuring element for '%s'. Error: %s ", element.getLabel(), e));
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
@@ -140,7 +140,7 @@ public class ErsdTransformer extends Operation {
 
     private PlanDefinition getV2PlanDefinition(String pathToPlanDefinition) {
         PlanDefinition planDef = null;
-        System.out.println(String.format("PlanDefinitionPath: '%s'", pathToPlanDefinition));
+        logger.info(String.format("PlanDefinitionPath: '%s'", pathToPlanDefinition));
         if (pathToPlanDefinition != null && !pathToPlanDefinition.isEmpty()) {
             planDef = (PlanDefinition)IOUtils.readResource(pathToPlanDefinition, ctx, true);
             planDef.setEffectivePeriod(this.effectivePeriod);
@@ -429,7 +429,7 @@ public class ErsdTransformer extends Operation {
     }
 
     private Bundle resolveSpecificationBundle(Bundle bundle, Library specificationLibrary) {
-        System.out.println(FhirContext.forR4Cached().newJsonParser().setPrettyPrint(true)
+        logger.info(FhirContext.forR4Cached().newJsonParser().setPrettyPrint(true)
                 .encodeResourceToString(specificationLibrary));
         List<BundleEntryComponent> entries = new ArrayList<BundleEntryComponent>();
         entries.add(new BundleEntryComponent().setResource(specificationLibrary)

--- a/tooling/src/main/java/org/opencds/cqf/tooling/library/BaseLibraryGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/library/BaseLibraryGenerator.java
@@ -21,8 +21,12 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.tooling.Operation;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class BaseLibraryGenerator<L extends IBaseResource, T extends BaseNarrativeProvider<?>> extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private T narrativeProvider;
     private FhirContext fhirContext;
@@ -198,7 +202,7 @@ public abstract class BaseLibraryGenerator<L extends IBaseResource, T extends Ba
                 );
 
             if (translator.getErrors().size() > 0) {
-                System.err.println("Translation failed due to errors:");
+                logger.error("Translation failed due to errors:");
                 ArrayList<String> errors = new ArrayList<>();
                 for (CqlCompilerException error : translator.getErrors()) {
                     TrackBack tb = error.getLocator();

--- a/tooling/src/main/java/org/opencds/cqf/tooling/library/LibraryProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/library/LibraryProcessor.java
@@ -57,7 +57,7 @@ public class LibraryProcessor extends BaseProcessor {
         return refreshIgLibraryContent(parentContext, outputEncoding, null, versioned, fhirContext, shouldApplySoftwareSystemStamp);
     }
     public List<String> refreshIgLibraryContent(BaseProcessor parentContext, Encoding outputEncoding, String libraryOutputDirectory, Boolean versioned, FhirContext fhirContext, Boolean shouldApplySoftwareSystemStamp) {
-        System.out.println("Refreshing libraries...");
+        logger.info("Refreshing libraries...");
         // ArrayList<String> refreshedLibraryNames = new ArrayList<String>();
 
         LibraryProcessor libraryProcessor;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
@@ -49,7 +49,7 @@ public class MeasureProcessor extends BaseProcessor {
 
     public List<String> refreshIgMeasureContent(BaseProcessor parentContext, Encoding outputEncoding, String measureOutputDirectory, Boolean versioned, FhirContext fhirContext, String measureToRefreshPath, Boolean shouldApplySoftwareSystemStamp) {
 
-        System.out.println("Refreshing measures...");
+        logger.info("Refreshing measures...");
 
         MeasureProcessor measureProcessor;
         switch (fhirContext.getVersion().getVersion()) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/Atlas.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/Atlas.java
@@ -33,8 +33,12 @@ import org.opencds.cqf.tooling.utilities.CanonicalUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Atlas {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public Atlas() {
         resources = new HashMap<>();
@@ -116,7 +120,7 @@ public class Atlas {
     public void loadPaths(String basePath, String resourcePaths) {
         String[] paths = resourcePaths.split(";");
         for (String path : paths) {
-            System.out.println("Reading " + path + " Conformance Resources");
+            logger.info("Reading " + path + " Conformance Resources");
             readConformanceResourcesFromFolder(Paths.get(basePath, path).toString());
         }
     }
@@ -139,7 +143,7 @@ public class Atlas {
             if (!resourcesById.containsKey(id)) {
                 resourcesById.put(id, sd);
             } else {
-                System.out.println("Duplicate url found for: " + sd.getUrl());
+                logger.info("Duplicate url found for: " + sd.getUrl());
             }
         }
 
@@ -154,11 +158,11 @@ public class Atlas {
                 capabilityStatements.put(id, capabilityStatement);
             }
             else {
-                System.out.println("Duplicate CapabilityStatement with id " + id);
+                logger.info("Duplicate CapabilityStatement with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + capabilityStatement.getUrl());
+            logger.info("Duplicate url found for: " + capabilityStatement.getUrl());
         }
     }
 
@@ -170,11 +174,11 @@ public class Atlas {
                 compartmentDefinitions.put(id, compartmentDefinition);
             }
             else {
-                System.out.println("Duplicate CompartmentDefinition with id " + id);
+                logger.info("Duplicate CompartmentDefinition with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + compartmentDefinition.getUrl());
+            logger.info("Duplicate url found for: " + compartmentDefinition.getUrl());
         }
     }
 
@@ -186,11 +190,11 @@ public class Atlas {
                 structureDefinitions.put(id, structureDefinition);
             }
             else {
-                System.out.println("Duplicate StructureDefinition with id " + id);
+                logger.info("Duplicate StructureDefinition with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + structureDefinition.getUrl());
+            logger.info("Duplicate url found for: " + structureDefinition.getUrl());
         }
     }
 
@@ -202,11 +206,11 @@ public class Atlas {
                 operationDefinitions.put(id, operationDefinition);
             }
             else {
-                System.out.println("Duplicate OperationDefinition with id " + id);
+                logger.info("Duplicate OperationDefinition with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + operationDefinition.getUrl());
+            logger.info("Duplicate url found for: " + operationDefinition.getUrl());
         }
     }
 
@@ -218,11 +222,11 @@ public class Atlas {
                 searchParameters.put(id, searchParameter);
             }
             else {
-                System.out.println("Duplicate SearchParameter with id " + id);
+                logger.info("Duplicate SearchParameter with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + searchParameter.getUrl());
+            logger.info("Duplicate url found for: " + searchParameter.getUrl());
         }
     }
 
@@ -234,11 +238,11 @@ public class Atlas {
                 implementationGuides.put(id, implementationGuide);
             }
             else {
-                System.out.println("Duplicate ImplementationGuide with id " + id);
+                logger.info("Duplicate ImplementationGuide with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + implementationGuide.getUrl());
+            logger.info("Duplicate url found for: " + implementationGuide.getUrl());
         }
     }
 
@@ -250,11 +254,11 @@ public class Atlas {
                 codeSystems.put(id, codeSystem);
             }
             else {
-                System.out.println("Duplicate CodeSystem with id " + id);
+                logger.info("Duplicate CodeSystem with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + codeSystem.getUrl());
+            logger.info("Duplicate url found for: " + codeSystem.getUrl());
         }
     }
 
@@ -266,11 +270,11 @@ public class Atlas {
                 valueSets.put(id, valueSet);
             }
             else {
-                System.out.println("Duplicate ValueSet with id " + id);
+                logger.info("Duplicate ValueSet with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + valueSet.getUrl());
+            logger.info("Duplicate url found for: " + valueSet.getUrl());
         }
     }
 
@@ -282,11 +286,11 @@ public class Atlas {
                 conceptMaps.put(id, conceptMap);
             }
             else {
-                System.out.println("Duplicate ConceptMap with id " + id);
+                logger.info("Duplicate ConceptMap with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + conceptMap.getUrl());
+            logger.info("Duplicate url found for: " + conceptMap.getUrl());
         }
     }
 
@@ -298,11 +302,11 @@ public class Atlas {
                 namingSystems.put(id, namingSystem);
             }
             else {
-                System.out.println("Duplicate NamingSystem with id " + id);
+                logger.info("Duplicate NamingSystem with id " + id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + namingSystem.getUrl());
+            logger.info("Duplicate url found for: " + namingSystem.getUrl());
         }
     }
 
@@ -338,7 +342,7 @@ public class Atlas {
             indexNamingSystem((NamingSystem)resource);
         }
         else {
-            System.out.println("Resource with id " + resource.getIdElement().toString() + " skipped");
+            logger.info("Resource with id " + resource.getIdElement().toString() + " skipped");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/ClassInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/ClassInfoBuilder.java
@@ -17,8 +17,12 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.StructureDefinition.StructureDefinitionKind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class ClassInfoBuilder {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
     protected Map<String, StructureDefinition> structureDefinitions;
     protected Map<String, TypeInfo> typeInfos = new HashMap<String, TypeInfo>();
     protected Map<String, String> typeTargets = new HashMap<String, String>();
@@ -664,7 +668,7 @@ public abstract class ClassInfoBuilder {
                 return this.buildTypeSpecifier(this.resolveMappedTypeName(modelName, typeRef));
             }
         } catch (Exception e) {
-            System.out.println("Error building type specifier for " + modelName + "."
+            logger.error("Error building type specifier for " + modelName + "."
                     + (typeRef != null ? typeRef.getCode() : "<No Type>") + ": " + e.getMessage());
             return null;
         }
@@ -899,7 +903,7 @@ public abstract class ClassInfoBuilder {
             }
         }
         catch (Exception e) {
-            System.out.println("Error building type specifier for " + modelName + "."
+            logger.error("Error building type specifier for " + modelName + "."
                     + ed.getId() + ": " + e.getMessage());
             return null;
         }
@@ -1004,7 +1008,7 @@ public abstract class ClassInfoBuilder {
             typeSpecifier = nts;
         }
 
-        System.out.println(String.format("Building ClassInfoElement for element %s", ed.getId()));
+        logger.info(String.format("Building ClassInfoElement for element %s", ed.getId()));
 
         // If the base is different than the path, it indicates the element is a restatement (or constraint) on an element
         // defined in a base class. If the path and id are different, it indicates a slice definition, which should only
@@ -1012,7 +1016,7 @@ public abstract class ClassInfoBuilder {
         if (ed.hasBase() && ed.getBase().hasPath() && !ed.getBase().getPath().startsWith(root)
                 || !ed.getId().equals(ed.getPath())) {
             if (ed.getSliceName() == null && !(ed.getBase() != null && ed.getPath().endsWith("[x]") && ed.getType() != null && ed.getType().size() == 1)) {
-                System.out.println(String.format("Element %s is a restatement (and not a choice constraint) of a base element, no ClassInfoElement created.", ed.getId()));
+                logger.info(String.format("Element %s is a restatement (and not a choice constraint) of a base element, no ClassInfoElement created.", ed.getId()));
                 return null;
             }
         }
@@ -1029,7 +1033,7 @@ public abstract class ClassInfoBuilder {
                 typeSpecifier = lts;
             }
             else if (this.asInteger(ed.getMax()) == 0) {
-                System.out.println(String.format("Element %s has max cardinality 0, no ClassInfoElement created", ed.getId()));
+                logger.info(String.format("Element %s has max cardinality 0, no ClassInfoElement created", ed.getId()));
                 return null;
             }
         }
@@ -1096,7 +1100,7 @@ public abstract class ClassInfoBuilder {
             }
         }
 
-        System.out.println(String.format("Done building ClassInfoElement %s: %s", cie.getName(), cie.toString()));
+        logger.info(String.format("Done building ClassInfoElement %s: %s", cie.getName(), cie.toString()));
 
         return cie;
     }
@@ -1155,7 +1159,7 @@ public abstract class ClassInfoBuilder {
 
         String id = ed.getId();
         String path = ed.getPath();
-        System.out.println(String.format("Visiting element %s, path %s", id, path));
+        logger.info(String.format("Visiting element %s, path %s", id, path));
 
         if (settings.createSliceElements) {
             if (ed.getSlicing() != null && !ed.getSlicing().isEmpty()) {
@@ -1165,10 +1169,10 @@ public abstract class ClassInfoBuilder {
 
             if (ed.hasSliceName()) {
                 if (sliceInfo == null) {
-                    System.out.println(String.format("WARNING: Slice %s is not defined as part of a valid slicing", ed.getSliceName()));
+                    logger.warn(String.format("WARNING: Slice %s is not defined as part of a valid slicing", ed.getSliceName()));
                 } else {
                     sliceInfo.setSliceName(ed.getSliceName());
-                    System.out.println(String.format("Started slice %s of slicing root %s", sliceInfo.getSliceName(), sliceInfo.getSliceRoot().getId()));
+                    logger.info(String.format("Started slice %s of slicing root %s", sliceInfo.getSliceName(), sliceInfo.getSliceRoot().getId()));
                 }
             }
 
@@ -1204,7 +1208,7 @@ public abstract class ClassInfoBuilder {
 
                 for (ClassInfoElement slice : elementSlices.getSlices()) {
                     // Slices other than type slices are reported to the containing element (or class)
-                    System.out.println(String.format("Adding slice %s to slice list of element %s", slice.getName(), ed.getId()));
+                    logger.info(String.format("Adding slice %s to slice list of element %s", slice.getName(), ed.getId()));
                     if (elementSlices.getSliceInfo() != null) {
                         // The slices have been collected at the discriminator, so bubbling them past this point means they need to be qualified
                         // by the path of the current element
@@ -1245,7 +1249,7 @@ public abstract class ClassInfoBuilder {
                 if (elementTypeInfo instanceof ClassInfo) {
                     ClassInfo elementClassInfo = (ClassInfo)elementTypeInfo;
                     for (ClassInfoElement slice : slices.getSlices()) {
-                        System.out.println(String.format("Adding slice %s to constructed type %s.", slice.getName(), elementClassInfo.getName()));
+                        logger.info(String.format("Adding slice %s to constructed type %s.", slice.getName(), elementClassInfo.getName()));
                         elementClassInfo.getElement().add(slice);
                     }
                     slices.getSlices().clear();
@@ -1258,7 +1262,7 @@ public abstract class ClassInfoBuilder {
         // If this element is a slice, set the target map for the element
         if (ed.hasSliceName() && sliceInfo != null) {
             if (elements.size() == 1) {
-                System.out.println(String.format("Element %s is the only element for slice %s, collapsing into the slice.", elements.get(0).getName(), ed.getSliceName()));
+                logger.info(String.format("Element %s is the only element for slice %s, collapsing into the slice.", elements.get(0).getName(), ed.getSliceName()));
                 cie = mergeElements(cie, elements.remove(0));
             }
             else if (elements.size() > 1) {
@@ -1280,7 +1284,7 @@ public abstract class ClassInfoBuilder {
             }
 
             if (!sliceInfo.isTypeSlicing()) {
-                System.out.println(String.format("Element %s is a slice of element %s, adding to slice list.", cie.getName(), sliceInfo.getSliceRoot().getId()));
+                logger.info(String.format("Element %s is a slice of element %s, adding to slice list.", cie.getName(), sliceInfo.getSliceRoot().getId()));
                 slices.getSlices().add(cie);
                 cie = null;
             }
@@ -1293,7 +1297,7 @@ public abstract class ClassInfoBuilder {
                     if (elements.size() > 1) {
                         throw new IllegalArgumentException("Multiple type slices encountered");
                     }
-                    System.out.println(String.format("Element %s is the only element of a type-discriminated slicing of element %s, collapsing into the element.", elements.get(0).getName(), ed.getId()));
+                    logger.info(String.format("Element %s is the only element of a type-discriminated slicing of element %s, collapsing into the element.", elements.get(0).getName(), ed.getId()));
                     cie = mergeElements(cie, elements.remove(0));
                 }
             }
@@ -1308,11 +1312,11 @@ public abstract class ClassInfoBuilder {
         if (!ed.hasSliceName() && !(sliceInfo != null && sliceInfo.getSliceRoot().getId().equals(ed.getId())) && (slices.getSlices().size() > 0)) {
 
             if (!(typeSpecifier instanceof NamedTypeSpecifier)) {
-                System.out.println(String.format("WARNING: Derived type for slicing support only support for named types. Ignoring slices of element %s", ed.getId()));
+                logger.warn(String.format("WARNING: Derived type for slicing support only support for named types. Ignoring slices of element %s", ed.getId()));
                 slices.getSlices().clear();
             }
             else if (!(isClassType(getTypeName((NamedTypeSpecifier)typeSpecifier)))) {
-                System.out.println(String.format("WARNING: Derived type for slicing support on primitives not implemented. Ignoring slices of element %s", ed.getId()));
+                logger.warn(String.format("WARNING: Derived type for slicing support on primitives not implemented. Ignoring slices of element %s", ed.getId()));
                 slices.getSlices().clear();
             }
             else if (isSystemTypeName(getTypeName((NamedTypeSpecifier)typeSpecifier)) && slices.getSlices().size() == 1 && slices.getSlices().get(0).getElementType() != null && slices.getSlices().get(0).getElementType().equals("QICore.NotDoneValueSet") && cie != null) {
@@ -1339,7 +1343,7 @@ public abstract class ClassInfoBuilder {
                     String qualifiedTypeName = getTypeName(modelName, typeName);
                     ClassInfo elementType = null;
                     if (this.typeInfos.containsKey(qualifiedTypeName)) {
-                        System.out.println(String.format("WARNING: Adding slices to existing type %s.", qualifiedTypeName));
+                        logger.warn(String.format("WARNING: Adding slices to existing type %s.", qualifiedTypeName));
                         elementType = (ClassInfo) typeInfos.get(qualifiedTypeName);
                     } else {
                         elementType = new ClassInfo().withNamespace(modelName).withName(typeName).withBaseTypeSpecifier(typeSpecifier).withRetrievable(false);
@@ -1347,11 +1351,11 @@ public abstract class ClassInfoBuilder {
                     }
 
                     for (ClassInfoElement slice : slices.getSlices()) {
-                        System.out.println(String.format("Adding slice %s to derived type %s", slice.getName(), qualifiedTypeName));
+                        logger.info(String.format("Adding slice %s to derived type %s", slice.getName(), qualifiedTypeName));
                         if (elementType.getElement().stream().noneMatch(x -> x.getName().equals(slice.getName()))) {
                             elementType.getElement().add(slice);
                         } else {
-                            System.out.println(String.format("WARNING: Duplicate element %s not added to derived type %s", slice.getName(), qualifiedTypeName));
+                            logger.warn(String.format("WARNING: Duplicate element %s not added to derived type %s", slice.getName(), qualifiedTypeName));
                         }
                     }
                     //this.typeInfos.put(qualifiedTypeName, elementType);
@@ -1381,7 +1385,7 @@ public abstract class ClassInfoBuilder {
         }
 
         for (ClassInfoElement slice : elements) {
-            System.out.println(String.format("WARNING: Element %s ignored", slice.getName()));
+            logger.warn(String.format("WARNING: Element %s ignored", slice.getName()));
         }
 
         return cie;
@@ -1396,7 +1400,7 @@ public abstract class ClassInfoBuilder {
         }
         String typeName = getTypeName(sd);
         String qualifiedTypeName = getTypeName(modelName, typeName);
-        System.out.println("Building ClassInfo for " + typeName);
+        logger.info("Building ClassInfo for " + typeName);
         ClassInfo info = new ClassInfo().withName(typeName).withNamespace(modelName).withLabel(this.getLabel(sd))
                 .withIdentifier(sd.getUrl())
                 .withRetrievable(sd.getKind() == StructureDefinitionKind.RESOURCE);
@@ -1429,7 +1433,7 @@ public abstract class ClassInfoBuilder {
 
                 // Slices of the element, if any
                 for (ClassInfoElement slice : elementSlices.getSlices()) {
-                    System.out.println(String.format("Adding slice %s to elements for %s", slice.getName(), typeName));
+                    logger.info(String.format("Adding slice %s to elements for %s", slice.getName(), typeName));
                     elements.add(slice);
                 }
             }
@@ -1466,7 +1470,7 @@ public abstract class ClassInfoBuilder {
                     .withPrimaryCodePath(this.primaryCodePath(elements, typeName));
         }
 
-        System.out.println(String.format("Done building ClassInfo for %s", typeName));
+        logger.info(String.format("Done building ClassInfo for %s", typeName));
         return info;
     }
 
@@ -1489,7 +1493,7 @@ public abstract class ClassInfoBuilder {
             this.buildClassInfo(model, structureDefinitions.get(id));
         }
         catch (Exception e) {
-            System.out.println("Error building ClassInfo for: " + id + " - " + e.getMessage());
+            logger.error("Error building ClassInfo for: " + id + " - " + e.getMessage());
             e.printStackTrace();
         }
     }
@@ -1501,7 +1505,7 @@ public abstract class ClassInfoBuilder {
                     this.buildClassInfo(model, sd);
                 }
                 catch (Exception e) {
-                    System.out.println("Error building ClassInfo for: " + sd.getId() + " - " + e.getMessage());
+                    logger.error("Error building ClassInfo for: " + sd.getId() + " - " + e.getMessage());
                     e.printStackTrace();
                 }
             }
@@ -1582,7 +1586,7 @@ public abstract class ClassInfoBuilder {
                     || this.isContentReferenceTypeSpecifier(element.getElementTypeSpecifier());
         }
         catch (Exception ex) {
-            System.out.println(ex.getMessage());
+            logger.error(ex.getMessage());
             throw ex;
         }
     }
@@ -1617,8 +1621,7 @@ public abstract class ClassInfoBuilder {
             }
         }
         catch (Exception e) {
-            System.out.println(String.format("Error fixing up contentreferencetypespecifier %s.%s: %s", modelName, element.getName(), e.getMessage()));
-            e.printStackTrace();
+            logger.error(String.format("Error fixing up contentreferencetypespecifier %s.%s: %s", modelName, element.getName(), e.getMessage()));
         }
 
         return result;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/ResourceLoader.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/ResourceLoader.java
@@ -22,8 +22,12 @@ import org.hl7.fhir.r4.model.StructureDefinition;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ResourceLoader {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public Map<String, StructureDefinition> loadPaths(String basePath, String resourcePaths) {
 
@@ -31,11 +35,11 @@ public class ResourceLoader {
 
         String[] paths = resourcePaths.split(";");
         for (String path : paths) {
-            System.out.println("Reading " + path + " StructureDefinitions");
+            logger.info("Reading " + path + " StructureDefinitions");
             resources.addAll(this.readStructureDefFromFolder(Paths.get(basePath, path).toString()));
         }
 
-        System.out.println("Indexing StructureDefinitions by Id");
+        logger.info("Indexing StructureDefinitions by Id");
         return this.indexResources(resources);
     }
 
@@ -56,7 +60,7 @@ public class ResourceLoader {
             if (!resourcesById.containsKey(id)) {
                 resourcesById.put(id, sd);
             } else {
-                System.out.println("Duplicate url found for: " + sd.getUrl());
+                logger.info("Duplicate url found for: " + sd.getUrl());
             }
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/StructureDefinitionToModelInfo.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/StructureDefinitionToModelInfo.java
@@ -25,12 +25,17 @@ import org.opencds.cqf.tooling.modelinfo.quick.QuickClassInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.quick.QuickModelInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.uscore.USCoreClassInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.uscore.USCoreModelInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 
 public class StructureDefinitionToModelInfo extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
 
     private String inputPath;
     private String resourcePaths;
@@ -229,7 +234,7 @@ public class StructureDefinitionToModelInfo extends Operation {
             String fileName = modelName.toLowerCase() + "-" + "modelinfo" + "-" + modelVersion + ".xml";
             writeOutput(fileName, sw.toString());
         } catch (Exception e) {
-            System.err.println("error" + e.getMessage());
+            logger.error("error" + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRClassInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRClassInfoBuilder.java
@@ -9,8 +9,12 @@ import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.StructureDefinition.StructureDefinitionKind;
 import org.hl7.fhir.r4.model.StructureDefinition.TypeDerivationRule;
 import org.opencds.cqf.tooling.modelinfo.ClassInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FHIRClassInfoBuilder extends ClassInfoBuilder {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public FHIRClassInfoBuilder(Map<String, StructureDefinition> structureDefinitions) {
         super(new FHIRClassInfoSettings(), structureDefinitions);
@@ -19,16 +23,16 @@ public class FHIRClassInfoBuilder extends ClassInfoBuilder {
     @Override
     protected void innerBuild() {
         if (!this.settings.useCQLPrimitives) {
-            System.out.println("Building Primitives");
+            logger.info("Building Primitives");
             this.buildFor("FHIR", (x -> x.getKind() == StructureDefinitionKind.PRIMITIVETYPE));
         }
 
-        System.out.println("Building ComplexTypes");
+        logger.info("Building ComplexTypes");
         this.buildFor("FHIR", (x -> (x.getKind() == StructureDefinitionKind.COMPLEXTYPE && (x.getBaseDefinition() == null
                 || !x.getBaseDefinition().equals("http://hl7.org/fhir/StructureDefinition/Extension")))
                 && !x.getUrl().equals("http://hl7.org/fhir/StructureDefinition/elementdefinition-de")));
 
-        System.out.println("Building Resources");
+        logger.info("Building Resources");
         this.buildFor("FHIR", (x -> x.getKind() == StructureDefinitionKind.RESOURCE
                 && (!x.hasDerivation() || x.getDerivation() == TypeDerivationRule.SPECIALIZATION)));
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRModelInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRModelInfoBuilder.java
@@ -15,8 +15,12 @@ import org.opencds.cqf.tooling.modelinfo.Atlas;
 import org.opencds.cqf.tooling.modelinfo.ContextInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.ModelInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.SearchInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FHIRModelInfoBuilder extends ModelInfoBuilder {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
     private String fhirHelpersPath;
     private SearchInfoBuilder searchInfoBuilder;
     private ContextInfoBuilder contextInfoBuilder;
@@ -324,7 +328,7 @@ public class FHIRModelInfoBuilder extends ModelInfoBuilder {
             pw.close();
         }
         catch (Exception e) {
-            System.out.println("Unable to write FileHelpers");
+            logger.error("Unable to write FileHelpers");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreModelInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreModelInfoBuilder.java
@@ -8,8 +8,11 @@ import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.opencds.cqf.tooling.modelinfo.Atlas;
 import org.opencds.cqf.tooling.modelinfo.ContextInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.ModelInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QICoreModelInfoBuilder extends ModelInfoBuilder {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
     private String helpersPath;
     private ContextInfoBuilder contextInfoBuilder;
 
@@ -137,7 +140,7 @@ public class QICoreModelInfoBuilder extends ModelInfoBuilder {
             pw.close();
         }
         catch (Exception e) {
-            System.out.println("Unable to write QICoreHelpers");
+            logger.error("Unable to write QICoreHelpers");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreModelInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreModelInfoBuilder.java
@@ -8,8 +8,11 @@ import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.opencds.cqf.tooling.modelinfo.Atlas;
 import org.opencds.cqf.tooling.modelinfo.ContextInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.ModelInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class USCoreModelInfoBuilder extends ModelInfoBuilder {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
     private String helpersPath;
     private ContextInfoBuilder contextInfoBuilder;
 
@@ -159,7 +162,7 @@ public class USCoreModelInfoBuilder extends ModelInfoBuilder {
             pw.close();
         }
         catch (Exception e) {
-            System.out.println("Unable to write USCoreHelpers");
+            logger.error("Unable to write USCoreHelpers");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -20,8 +20,13 @@ import org.opencds.cqf.tooling.utilities.IOUtils.Encoding;
 import org.opencds.cqf.tooling.utilities.LogUtils;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IGProcessor extends BaseProcessor {
+
+    private static Logger logger = LoggerFactory.getLogger(IGProcessor.class);
+
     public static final String IG_VERSION_REQUIRED = "igVersion required";
 	protected IGBundleProcessor igBundleProcessor;
     protected LibraryProcessor libraryProcessor;
@@ -243,7 +248,7 @@ public class IGProcessor extends BaseProcessor {
     private static void checkForDirectory(String igPath, String pathElement) {
         File directory = new File(FilenameUtils.concat(igPath, pathElement));
         if (!directory.exists()) {
-            System.out.println("No directory found by convention for: " + directory.getName());
+            logger.info("No directory found by convention for: " + directory.getName());
         }
         else {
             // TODO: This is a concept different from "resource directories". It is expected elsewhere (e.g., IOUtils.setupActivityDefinitionPaths)

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGTestProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGTestProcessor.java
@@ -13,6 +13,8 @@ import org.opencds.cqf.tooling.common.CqfmSoftwareSystem;
 import org.opencds.cqf.tooling.measure.MeasureTestProcessor;
 import org.opencds.cqf.tooling.parameter.TestIGParameters;
 import org.opencds.cqf.tooling.utilities.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;
@@ -20,6 +22,8 @@ import java.util.stream.Collectors;
 
 
 public class IGTestProcessor extends BaseProcessor {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public class TestCaseResultSummaryComparator implements Comparator<TestCaseResultSummary> {
         public int compare(TestCaseResultSummary o1, TestCaseResultSummary o2) {
@@ -168,7 +172,7 @@ public class IGTestProcessor extends BaseProcessor {
 
         CqfmSoftwareSystem testTargetSoftwareSystem =  getCqfRulerSoftwareSystem(params.fhirServerUri);
 
-        System.out.println("Running IG test cases...");
+        logger.info("Running IG test cases...");
 
         File testCasesDirectory = new File(params.testCasesPath);
         if (!testCasesDirectory.isDirectory()) {
@@ -176,7 +180,7 @@ public class IGTestProcessor extends BaseProcessor {
         }
 
         // refresh/generate test bundles
-        System.out.println("Refreshing test cases...");
+        logger.info("Refreshing test cases...");
         TestCaseProcessor testCaseProcessor = new TestCaseProcessor();
         testCaseProcessor.refreshTestCases(params.testCasesPath, IOUtils.Encoding.JSON, fhirContext);
 
@@ -186,21 +190,21 @@ public class IGTestProcessor extends BaseProcessor {
         //TODO: How can we validate the set of directories here - that they're actually FHIR resources - and message when they're not. Really it doesn't matter, it can be any grouping so long as it has a corresponding path in /bundles.
 
         for (File group : resourceTypeTestGroups) {
-            System.out.println(String.format("Processing %s test cases...", group.getName()));
+            logger.info(String.format("Processing %s test cases...", group.getName()));
 
             // Get set of test artifacts
             File[] testArtifactNames = group.listFiles(file -> file.isDirectory());
 
             for (File testArtifact : testArtifactNames) {
-                System.out.println(String.format("  Processing test cases for %s: %s", group.getName(), testArtifact.getName()));
+                logger.info(String.format("  Processing test cases for %s: %s", group.getName(), testArtifact.getName()));
                 Boolean allTestArtifactTestsPassed = true;
 
                 // Get content bundle
                 Map.Entry<String, IBaseResource> testArtifactContentBundleMap = getContentBundleForTestArtifact(group.getName(), testArtifact.getName());
 
                 if ((testArtifactContentBundleMap == null) || testArtifactContentBundleMap.getValue() == null) {
-                    System.out.println(String.format("      No content bundle found for %s: %s", group.getName(), testArtifact.getName()));
-                    System.out.println(String.format("  Done processing all test cases for %s: %s", group.getName(), testArtifact.getName()));
+                    logger.info(String.format("      No content bundle found for %s: %s", group.getName(), testArtifact.getName()));
+                    logger.info(String.format("  Done processing all test cases for %s: %s", group.getName(), testArtifact.getName()));
                     continue;
                 }
 
@@ -213,7 +217,7 @@ public class IGTestProcessor extends BaseProcessor {
                     TestCaseResultSummary testCaseResult  = new TestCaseResultSummary(group.getName(), testArtifact.getName(),
                         testCaseBundle.getIdElement().toString());
                     try {
-                        System.out.println(String.format("      Starting processing of test case '%s' for %s: %s", testCaseBundle.getIdElement(), group.getName(), testArtifact.getName()));
+                        logger.info(String.format("      Starting processing of test case '%s' for %s: %s", testCaseBundle.getIdElement(), group.getName(), testArtifact.getName()));
                         Parameters testResults = testProcessor.executeTest(testCaseBundle, testArtifactContentBundleMap.getValue(), params.fhirServerUri);
 
                         Boolean testPassed = false;
@@ -224,16 +228,16 @@ public class IGTestProcessor extends BaseProcessor {
                             }
                         }
                         testCaseResult.setTestPassed(testPassed);
-                        System.out.println(String.format("      Done processing test case '%s' for %s: %s", testCaseBundle.getIdElement(), group.getName(), testArtifact.getName()));
+                        logger.info(String.format("      Done processing test case '%s' for %s: %s", testCaseBundle.getIdElement(), group.getName(), testArtifact.getName()));
                     } catch (Exception ex) {
                         testCaseResult.setTestPassed(false);
                         testCaseResult.setMessage(ex.getMessage());
-                        System.out.println(String.format("      Error: Test case '%s' for %s: %s failed with message: %s", testCaseBundle.getIdElement(), group.getName(), testArtifact.getName(), ex.getMessage()));
+                        logger.error(String.format("      Error: Test case '%s' for %s: %s failed with message: %s", testCaseBundle.getIdElement(), group.getName(), testArtifact.getName(), ex.getMessage()));
                     }
                     TestResults.add(testCaseResult);
                 }
 
-                System.out.println(String.format("  Done processing all test cases for %s: %s", group.getName(), testArtifact.getName()));
+                logger.info(String.format("  Done processing all test cases for %s: %s", group.getName(), testArtifact.getName()));
 
                 if (allTestArtifactTestsPassed) {
                     List<CqfmSoftwareSystem> softwareSystems = new ArrayList<CqfmSoftwareSystem>() {
@@ -257,7 +261,7 @@ public class IGTestProcessor extends BaseProcessor {
                 }
             }
 
-            System.out.println(String.format("Done processing %s test cases", group.getName()));
+            logger.info(String.format("Done processing %s test cases", group.getName()));
         }
 
         TestCaseResultSummaryComparator comparator = new TestCaseResultSummaryComparator();
@@ -266,7 +270,7 @@ public class IGTestProcessor extends BaseProcessor {
         List<TestCaseResultSummary> passedTests = new ArrayList<TestCaseResultSummary>();
         List<TestCaseResultSummary> failedTests = new ArrayList<TestCaseResultSummary>();
         for (TestCaseResultSummary result : TestResults) {
-            System.out.println(result.toString());
+            logger.info(result.toString());
             if (result.testPassed) {
                 passedTests.add(result);
             } else {
@@ -274,8 +278,8 @@ public class IGTestProcessor extends BaseProcessor {
             }
         }
 
-        System.out.println(String.format("%d tests failed", failedTests.size()));
-        System.out.println(String.format("%d tests passed", passedTests.size()));
+        logger.info(String.format("%d tests failed", failedTests.size()));
+        logger.info(String.format("%d tests passed", passedTests.size()));
     }
 
     private Map.Entry<String, IBaseResource> getContentBundleForTestArtifact(String groupName, String testArtifactName) {
@@ -308,7 +312,7 @@ public class IGTestProcessor extends BaseProcessor {
                 break;
             default:
                 // Currently unsupported/undocumented
-                System.out.println(String.format("No test processor implemented for resource type: $s", resourceTypeName));
+                logger.info(String.format("No test processor implemented for resource type: %s", resourceTypeName));
                 break;
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/PostBundlesInDirProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/PostBundlesInDirProcessor.java
@@ -10,9 +10,13 @@ import org.opencds.cqf.tooling.utilities.HttpClientUtils;
 import org.opencds.cqf.tooling.utilities.IOUtils.Encoding;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PostBundlesInDirProcessor {
-    
+    private static Logger logger = LoggerFactory.getLogger(PostBundlesInDirProcessor.class);
+
+
     public enum FHIRVersion {
         FHIR3("fhir3"), FHIR4("fhir4");
 
@@ -64,9 +68,9 @@ public class PostBundlesInDirProcessor {
         if (fhirUri != null && !fhirUri.equals("")) {  
             try {
                 HttpClientUtils.post(fhirUri, bundle, encoding, fhirContext);
-                System.out.println("Resource successfully posted to FHIR server (" + fhirUri + "): " + bundle.getIdElement().getIdPart());
+                logger.info("Resource successfully posted to FHIR server (" + fhirUri + "): " + bundle.getIdElement().getIdPart());
             } catch (Exception e) {
-                System.out.println(bundle.getIdElement().getIdPart() + e);             
+                logger.error(bundle.getIdElement().getIdPart() + e);
             }  
         }
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/TestCaseProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/TestCaseProcessor.java
@@ -15,16 +15,20 @@ import org.opencds.cqf.tooling.utilities.LogUtils;
 import org.opencds.cqf.tooling.utilities.ResourceUtils;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestCaseProcessor
 {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
     public void refreshTestCases(String path, IOUtils.Encoding encoding, FhirContext fhirContext) {
         refreshTestCases(path, encoding, fhirContext, null);
     }
 
     public void refreshTestCases(String path, IOUtils.Encoding encoding, FhirContext fhirContext, @Nullable List<String> refreshedResourcesNames)
     {
-        System.out.println("Refreshing tests");
+        logger.info("Refreshing tests");
         List<String> resourceTypeTestGroups = IOUtils.getDirectoryPaths(path, false);
 
         for (String group : resourceTypeTestGroups) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
@@ -13,8 +13,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.opencds.cqf.tooling.Operation;
 
 import info.bliki.wiki.model.WikiModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QdmToQiCore extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final String[] typeURLS = {
             "Adverse_Event_(QDM)", "Allergy/Intolerance_(QDM)", "Assessment_(QDM)",
@@ -45,7 +49,7 @@ public class QdmToQiCore extends Operation {
             try {
                 url = new URL(fullURL);
             } catch (MalformedURLException e) {
-                System.err.println("Encountered the following malformed URL: " + fullURL);
+                logger.error("Encountered the following malformed URL: " + fullURL);
                 e.printStackTrace();
                 return;
             }
@@ -54,7 +58,7 @@ public class QdmToQiCore extends Operation {
             try {
                 content = getCleanContent(getPageContent(url));
             } catch (IOException e) {
-                System.err.println("Encountered the following exception while scraping content from " + fullURL + ": " + e.getMessage());
+                logger.error("Encountered the following exception while scraping content from " + fullURL + ": " + e.getMessage());
                 e.printStackTrace();
                 return;
             }
@@ -85,7 +89,7 @@ public class QdmToQiCore extends Operation {
             try {
                 writeOutput(fileName, html);
             } catch (IOException e) {
-                System.err.println("Encountered the following exception while creating file " + fileName + ".html: " + e.getMessage());
+                logger.error("Encountered the following exception while creating file " + fileName + ".html: " + e.getMessage());
                 e.printStackTrace();
                 return;
             }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
@@ -20,8 +20,12 @@ import org.jsoup.nodes.Element;
 import org.opencds.cqf.tooling.Operation;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QuickPageGenerator extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     // Assuming R4
     private FhirContext context = FhirContext.forR4Cached();
@@ -68,7 +72,7 @@ public class QuickPageGenerator extends Operation {
      */
     private void processQiCoreProfiles() throws IOException, FHIRException {
         for (Map.Entry<String, StructureDefinition> entrySet : atlas.getQicoreProfiles().entrySet()) {
-            System.out.println("Processing the " + entrySet.getKey() + " profile...");
+            logger.info("Processing the " + entrySet.getKey() + " profile...");
 
             // Initialize HTML page
             HtmlBuilder html = new HtmlBuilder(entrySet.getKey(), atlas);
@@ -207,7 +211,7 @@ public class QuickPageGenerator extends Operation {
                             html.buildRow(mustSupport, isModifier, qicoreExtension, field, card, type, description);
                         }
 
-                        System.out.println(
+                        logger.info(
                                 String.format("Field: %s, Card: %s, Type: %s, Description: %s", field, card, type, description)
                         );
                     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetMeta.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetMeta.java
@@ -13,8 +13,11 @@ import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DistributableValueSetMeta {
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private String id;
     private String version;
@@ -81,7 +84,7 @@ public class DistributableValueSetMeta {
                 vs.setCompose(tempVs.getCompose());
             } catch (Exception e) {
                 //
-                System.out.println("Error parsing compose for: " + vs.getId());
+                logger.error("Error parsing compose for: " + vs.getId());
             }
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/CPGMeta.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/CPGMeta.java
@@ -2,11 +2,16 @@ package org.opencds.cqf.tooling.terminology.templateToValueSetGenerator;
 
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Date;
 
 public class CPGMeta {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private String id;
     private String version;
     private String name;
@@ -97,8 +102,8 @@ public class CPGMeta {
                 ValueSet tempVs = fhirContext.newXmlParser().parseResource(ValueSet.class, "<ValueSet>" + compose + "</ValueSet>");
                 vs.setCompose(tempVs.getCompose());
             } catch (Exception e) {
-                System.out.println("An error occurred in the compose for the sheet with id: " + this.id);
-                e.printStackTrace();
+                logger.info("An error occurred in the compose for the sheet with id: " + this.id);
+                logger.error(e.getMessage());
             }
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/TemplateToValueSetGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/TemplateToValueSetGenerator.java
@@ -25,8 +25,12 @@ import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
 import org.opencds.cqf.tooling.terminology.distributable.OrganizationalMetaData;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TemplateToValueSetGenerator extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private FhirContext fhirContext;
 
@@ -298,7 +302,7 @@ public class TemplateToValueSetGenerator extends Operation {
                     if (cpgMeta.getTitle().equals("only fill this out"))
                         continue;
                 } catch (NullPointerException e) {
-                    System.out.println("cpg instance had null title");
+                    logger.error("cpg instance had null title");
                 }
 
                 vs = cpgMeta.populate(fhirContext, outputVersion);
@@ -322,7 +326,7 @@ public class TemplateToValueSetGenerator extends Operation {
                 }
                 valueSets.add(vs);
             } else {
-                System.out.println("Workbook does NOT contain a sheet named " + entrySet.getKey());
+                logger.info("Workbook does NOT contain a sheet named " + entrySet.getKey());
             }
         }
         return valueSets;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/Helper.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/Helper.java
@@ -5,13 +5,15 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.opencds.cqf.tooling.terminology.templateToValueSetGenerator.testcase.TestCaseOld;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
 
 public class Helper {
 
-
+    private static Logger logger = LoggerFactory.getLogger(Helper.class);
 
 
     // Assumption made:
@@ -41,12 +43,12 @@ public class Helper {
         if (ret.contains("FALSE")) return "false";
 
         String[] tmp = ret.split("=");
-        System.out.println(inputCell.getStringCellValue());
+        logger.info(inputCell.getStringCellValue());
         String name = ret.split("=")[0];
         String condition = ret.split(" = ")[1];
 
 
-        System.out.println(String.format("%s RET RET RET", ret));
+        logger.info(String.format("%s RET RET RET", ret));
         return name;
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/TestCaseGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/TestCaseGenerator.java
@@ -25,8 +25,13 @@ import org.opencds.cqf.tooling.terminology.templateToValueSetGenerator.testcase.
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestCaseGenerator extends Operation {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private final FhirContext ctx = FhirContext.forR4Cached();
     private final IParser parser = ctx.newJsonParser();
     private final List<GuidanceResponse> guidanceResponses = new ArrayList<>();
@@ -102,7 +107,7 @@ public class TestCaseGenerator extends Operation {
         HashMap<String, String>logicInputCorrelations = buildInputCorrelatedHashmap(logicSheet, true, 5);
 
         for (Map.Entry<String, String> i : logicInputCorrelations.entrySet())
-            System.out.println(i.getKey() + " : " + i.getValue());
+            logger.info(i.getKey() + " : " + i.getValue());
 
         sortedLogicSheets = Helper.getSortedSheets(logicWorkbook);
         sortedDictSheets  = Helper.getSortedSheets(dictWorkbook);
@@ -274,7 +279,7 @@ public class TestCaseGenerator extends Operation {
 
     private void output(TestCase testCase) {
         String guidanceResponsePath = outputPath + "/testCase-" + testCase.getId().replace("/", "-").toLowerCase() + ".json";
-        System.out.println(testCase.getId());
+        logger.info(testCase.getId());
 
         if (guidanceResponsePath.contains("="))
             guidanceResponsePath = guidanceResponsePath.replace("=", "");

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -41,10 +41,13 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeCompositeDatatypeDefinition;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IOUtils 
-{        
-    
+{
+    private static Logger logger = LoggerFactory.getLogger(IOUtils.class);
+
     public enum Encoding 
     { 
         CQL("cql"), JSON("json"), XML("xml"), UNKNOWN(""); 
@@ -390,7 +393,7 @@ public class IOUtils
         try {
             directories = Arrays.asList(Optional.ofNullable(parentDirectory.listFiles()).<NoSuchElementException>orElseThrow(() -> new NoSuchElementException()));
         } catch (Exception e) {
-            System.out.println("No paths found for the Directory " + path + ":");
+            logger.error("No paths found for the Directory " + path + ":");
             return directoryPaths;
         }
         
@@ -683,7 +686,7 @@ public class IOUtils
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
                     if (path.toLowerCase().contains("valuesets") || path.toLowerCase().contains("valueset")) {
-                        System.out.println("Error reading in Terminology from path: " + path + "\n" + e);
+                        logger.error("Error reading in Terminology from path: " + path + "\n" + e);
                     }
                 }
             }
@@ -755,7 +758,7 @@ public class IOUtils
                     resources.put(path, resource);
                 } catch (Exception e) {
                     if(path.toLowerCase().contains("library")) {
-                        System.out.println("Error reading in Library from path: " + path + "\n" + e);
+                        logger.error("Error reading in Library from path: " + path + "\n" + e);
                     }
                 }
             }
@@ -806,7 +809,7 @@ public class IOUtils
                     resources.put(path, resource);
                 } catch (Exception e) {
                     if(path.toLowerCase().contains("measure")) {
-                        System.out.println("Error reading in Measure from path: " + path + "\n" + e);
+                        logger.error("Error reading in Measure from path: " + path + "\n" + e);
                     }
                 }
             }
@@ -881,7 +884,7 @@ public class IOUtils
                 try {
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
-                    System.out.println(String.format("Error setting PlanDefinition paths while reading resource at: '%s'. Error: %s", path, e.getMessage()));
+                    logger.error(String.format("Error setting PlanDefinition paths while reading resource at: '%s'. Error: %s", path, e.getMessage()));
                 }
             }
             RuntimeResourceDefinition planDefinitionDefinition = ResourceUtils.getResourceDefinition(fhirContext, "PlanDefinition");
@@ -929,7 +932,7 @@ public class IOUtils
                 try {
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
-                    System.out.println(String.format("Error setting Questionnaire paths while reading resource at: '%s'. Error: %s", path, e.getMessage()));
+                    logger.error(String.format("Error setting Questionnaire paths while reading resource at: '%s'. Error: %s", path, e.getMessage()));
                 }
             }
             RuntimeResourceDefinition questionnaireDefinition = ResourceUtils.getResourceDefinition(fhirContext, "Questionnaire");
@@ -948,7 +951,7 @@ public class IOUtils
     private static HashSet<String> activityDefinitionPaths = new LinkedHashSet<String>();
     public static HashSet<String> getActivityDefinitionPaths(FhirContext fhirContext) {
         if (activityDefinitionPaths.isEmpty()) {
-            System.out.println("Reading activitydefinitions");
+            logger.info("Reading activitydefinitions");
             setupActivityDefinitionPaths(fhirContext);
         }
         return activityDefinitionPaths;
@@ -1011,7 +1014,7 @@ public class IOUtils
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
                     if(path.toLowerCase().contains("device")) {
-                        System.out.println("Error reading in Device from path: " + path + "\n" + e);
+                        logger.error("Error reading in Device from path: " + path + "\n" + e);
                     }
                 }
             }
@@ -1031,7 +1034,7 @@ public class IOUtils
                 fileExtension.equalsIgnoreCase("json")){
             return true;
         }
-        System.out.println("The file " + fileDirPath + libraryName + " is not the right type of file.");
+        logger.info("The file " + fileDirPath + libraryName + " is not the right type of file.");
         return false;
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -316,7 +316,7 @@ public class ResourceUtils
         for (String valueSetUrl : dependencies) {
           message += valueSetUrl + " MISSING \r\n";
         }
-        System.out.println(message);
+        logger.error(message);
         throw new Exception(message);
       }
       return valueSetResources;
@@ -347,8 +347,8 @@ public class ResourceUtils
       try {
         elm = getElmFromCql(cqlContentPath);
       } catch (Exception e) {
-        System.out.println("error processing cql: ");
-        System.out.println(e.getMessage());
+        logger.error("error processing cql: ");
+        logger.error(e.getMessage());
         return includedDefs;
       }
 
@@ -366,7 +366,7 @@ public class ResourceUtils
       try {
         elm = getElmFromCql(cqlContentPath);
       } catch (Exception e) {
-        System.out.println("error translating cql: ");
+        logger.error("error translating cql: ");
         return valueSetDefs;
       }
       if (elm.getValueSets() != null && !elm.getValueSets().getDef().isEmpty()) {


### PR DESCRIPTION
-Operation outputs have been unchanged as these should be visible via CLI


**Description**

Various parts of the tooling log errors / warnings to System.out instead of a logging framework. This makes it difficult to redirect logging to a file or to distinguish errors from the actual output.

This change routes output to the SLF4J logging framework, except for in cases where the outputs are required by the CLI.

- Github Issue:  https://github.com/cqframework/cqf-tooling/issues/262
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
