### PR TITLE
Replace use of System.out/System.err with SLF4J Logging

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/DTProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/DTProcessor.java
@@ -35,8 +35,13 @@ import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DTProcessor extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(DTProcessor.class);
+
     private String pathToSpreadsheet; // -pathtospreadsheet (-pts)
     private String encoding = "json"; // -encoding (-e)
 
@@ -120,10 +125,10 @@ public class DTProcessor extends Operation {
     private void processDecisionTablePage(Workbook workbook, String page) {
         Sheet sheet = workbook.getSheet(page);
         if (sheet == null) {
-            System.out.println(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
+            logger.info(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
         }
         else {
-            System.out.println(String.format("Processing Sheet %s.", page));
+            logger.info(String.format("Processing Sheet %s.", page));
             processDecisionTableSheet(workbook, sheet);
         }
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/Processor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/Processor.java
@@ -42,11 +42,15 @@ import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by Bryn on 8/18/2019.
  */
 public class Processor extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(Processor.class);
     private String pathToSpreadsheet; // -pathtospreadsheet (-pts)
     private String encoding = "json"; // -encoding (-e)
     private String scopes; // -scopes (-s)
@@ -906,7 +910,7 @@ public class Processor extends Operation {
     private void processDataElementPage(Workbook workbook, String page, String scope) {
         Sheet sheet = workbook.getSheet(page);
         if (sheet == null) {
-            System.out.println(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
+            logger.info(String.format("Sheet %s not found in the Workbook, so no processing was done.", page));
         }
 
         questionnaireItemLinkIdCounter = 1;
@@ -1143,7 +1147,7 @@ public class Processor extends Operation {
         }
 
         if (typeString == null || typeString.isEmpty()) {
-            System.out.println(String.format("Could not determine type for Data Element: %s.", dataElement.getDataElementLabel()));
+            logger.info(String.format("Could not determine type for Data Element: %s.", dataElement.getDataElementLabel()));
             return type;
         }
 
@@ -1188,7 +1192,7 @@ public class Processor extends Operation {
                 type = Questionnaire.QuestionnaireItemType.QUANTITY;
                 break;
             default:
-                System.out.println(String.format("Questionnaire Item Type not mapped: %s.", typeString));
+                logger.info(String.format("Questionnaire Item Type not mapped: %s.", typeString));
         }
 
         return type;
@@ -1204,7 +1208,7 @@ public class Processor extends Operation {
         if (questionnaireItemType != null) {
             questionnaireItem.setType(questionnaireItemType);
         } else {
-            System.out.println(String.format("Unable to determine questionnaire item type for item '%s'.", dataElement.getDataElementLabel()));
+            logger.info(String.format("Unable to determine questionnaire item type for item '%s'.", dataElement.getDataElementLabel()));
         }
 
         questionnaire.getItem().add(questionnaireItem);
@@ -2036,7 +2040,7 @@ public class Processor extends Operation {
             ensureChoicesDataElement(element, sd);
 
         } catch (Exception e) {
-            System.out.println(String.format("Error ensuring element for '%s'. Error: %s ", element.getLabel(), e));
+            logger.error(String.format("Error ensuring element for '%s'. Error: %s ", element.getLabel(), e));
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/casereporting/transformer/ErsdTransformer.java
@@ -140,7 +140,7 @@ public class ErsdTransformer extends Operation {
 
     private PlanDefinition getV2PlanDefinition(String pathToPlanDefinition) {
         PlanDefinition planDef = null;
-        System.out.println(String.format("PlanDefinitionPath: '%s'", pathToPlanDefinition));
+        logger.info(String.format("PlanDefinitionPath: '%s'", pathToPlanDefinition));
         if (pathToPlanDefinition != null && !pathToPlanDefinition.isEmpty()) {
             planDef = (PlanDefinition)IOUtils.readResource(pathToPlanDefinition, ctx, true);
             planDef.setEffectivePeriod(this.effectivePeriod);
@@ -429,7 +429,7 @@ public class ErsdTransformer extends Operation {
     }
 
     private Bundle resolveSpecificationBundle(Bundle bundle, Library specificationLibrary) {
-        System.out.println(FhirContext.forR4Cached().newJsonParser().setPrettyPrint(true)
+        logger.info(FhirContext.forR4Cached().newJsonParser().setPrettyPrint(true)
                 .encodeResourceToString(specificationLibrary));
         List<BundleEntryComponent> entries = new ArrayList<BundleEntryComponent>();
         entries.add(new BundleEntryComponent().setResource(specificationLibrary)

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/DroolCqlGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/DroolCqlGenerator.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @since   2021-02-24 
  */
 public class DroolCqlGenerator implements CqlGenerator {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(DroolCqlGenerator.class);
     private CQLTYPES type;
     private File cqlOutput;
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/DefinitionConverter.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/DefinitionConverter.java
@@ -31,11 +31,10 @@ import org.slf4j.MarkerFactory;
  * @since 2021-02-24
  */
 public class DefinitionConverter {
-    private Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(DefinitionConverter.class);
     private Map<String, Marker> markers = new HashMap<String, Marker>();
 
     public DefinitionConverter() {
-        logger = LoggerFactory.getLogger(this.getClass());
         markers.put("ExpressionDef", MarkerFactory.getMarker("ExpressionDef"));
     }
     private String identifier;
@@ -153,7 +152,7 @@ public class DefinitionConverter {
                     index++;
                 }
             } else if (referenceStack.size() <= actualListSize.intValue()) {
-                logger.warn(markers.get("ExpressionDef"), "missing Expression Reference, expected " + actualListSize + " but found " + referenceStack.size() + ".");
+                logger.warn(markers.get("ExpressionDef"), "missing Expression Reference, expected {} but found {}.", actualListSize, referenceStack.size());
                 for (Pair<String, ExpressionRef> reference : referenceStack) {
                     if (expressionDef == null) {
                         expressionDef = adaptExpressionDef(libraryBuilder, modelBuilder, reference.getRight());

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/DroolPredicateToElmExpressionConverter.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/DroolPredicateToElmExpressionConverter.java
@@ -69,7 +69,7 @@ public class DroolPredicateToElmExpressionConverter {
     private boolean startedFunction = false;
 
     public static Set<String> valueSetIds = new HashSet<String>();
-    private Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(DroolPredicateToElmExpressionConverter.class);
     private Map<String, Marker> markers = new HashMap<String, Marker>();
 
     /**
@@ -77,7 +77,6 @@ public class DroolPredicateToElmExpressionConverter {
      * @param modelBuilder modelBuilder
     */
     public DroolPredicateToElmExpressionConverter(VmrToModelElmBuilder modelBuilder) {
-        logger = LoggerFactory.getLogger(this.getClass());
         this.modelBuilder = modelBuilder;
         markers.put("Left_Operand", MarkerFactory.getMarker("Left_Operand"));
         markers.put("Right_Operand", MarkerFactory.getMarker("Right_Operand"));

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/LibraryConverter.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/converter/LibraryConverter.java
@@ -21,11 +21,10 @@ import org.slf4j.MarkerFactory;
  */
 public class LibraryConverter {
 
-    private Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(LibraryConverter.class);
     private Map<String, Marker> markers = new HashMap<String, Marker>();
 
     public LibraryConverter() {
-        logger = LoggerFactory.getLogger(this.getClass());
         markers.put("Library", MarkerFactory.getMarker("Library"));
     }
 
@@ -47,7 +46,7 @@ public class LibraryConverter {
             logger.error(markers.get("Library"), "conditionCriteriaRel.getCriteriaDTO() was null.");
             throw new RuntimeException("Unable to infer library name for condition " + conditionDTO.getUuid().toString());
         }
-        logger.debug("Resolving context for library " + libraryName);
+        logger.debug("Resolving context for library {}", libraryName);
         return resolveContext(libraryName, header, modelBuilder);
     }
 
@@ -69,7 +68,7 @@ public class LibraryConverter {
             logger.error(markers.get("Library"), "conditionCriteriaRel.getCriteriaDTO() was null.");
             throw new RuntimeException("Unable to infer library name for condition " + conditionCriteriaRel.getUuid().toString());
         }
-        logger.debug("Resolving context for library " + libraryName);
+        logger.debug("Resolving context for library {}", libraryName);
         return resolveContext(libraryName, header, modelBuilder);
     }
 
@@ -81,11 +80,11 @@ public class LibraryConverter {
                         .replaceAll("TEST", "").replaceAll("TEST2", "").replaceAll("TEST3", "")
                         .replaceAll("TESTExample-Daryl", "").replaceAll("[()]", "");
             } else {
-                logger.info("Descriptive name was too long, generating library name for " + libraryName);
+                logger.info("Descriptive name was too long, generating library name for {}", libraryName);
                 libraryName = "GeneratedCql" + libraryIndex;
             }
         } catch (Exception e) {
-            logger.error(markers.get("Library"), "Could not infer library name for " + libraryName);
+            logger.error(markers.get("Library"), "Could not infer library name for {}", libraryName);
             libraryName = "ErrorWhileGenerated" + libraryIndex;
         }
         return libraryName;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/traversal/DepthFirstDroolTraverser.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/traversal/DepthFirstDroolTraverser.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DepthFirstDroolTraverser<T> extends DroolTraverser<Visitor> {
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(DepthFirstDroolTraverser.class);
     private Stack<CriteriaResourceParamDTO> criteriaResourceParamDTOExtensionStack = new Stack<CriteriaResourceParamDTO>();
     private Boolean unableToDetermineModeling = false;
     public DepthFirstDroolTraverser(Visitor visitor) {
@@ -52,7 +52,7 @@ public class DepthFirstDroolTraverser<T> extends DroolTraverser<Visitor> {
             .filter(rel ->
             rel.getConditionCriteriaPredicateDTOs().isEmpty()
              || rel.getName().toLowerCase().contains("not yet implemented"))
-            .forEach(rel -> logger.info("Not Yet Implemented: " + rel.getUuid()));
+            .forEach(rel -> logger.info("Not Yet Implemented: {}", rel.getUuid()));
 
             conditionCriteriaRels.stream()
             .filter(rel ->
@@ -121,7 +121,7 @@ public class DepthFirstDroolTraverser<T> extends DroolTraverser<Visitor> {
             criteriaResourceParamDTOExtensionStack.push(predicatePart.getCriteriaResourceParamDTO());
         }
         if (unknownOperatorModeling(predicatePart)) {
-            logger.info("Unable to determine operator from " + predicatePart.getCriteriaResourceDTO().getUuid());
+            logger.info("Unable to determine operator from {}", predicatePart.getCriteriaResourceDTO().getUuid());
             unableToDetermineModeling = true;
             return;
         }
@@ -154,12 +154,12 @@ public class DepthFirstDroolTraverser<T> extends DroolTraverser<Visitor> {
                     }
                 } else if (sourcePredicatePartDTO.getDataInputClassType().equals(DataModelClassType.String)) {
                     if (sourcePredicatePartDTO.getPartAlias() != null && sourcePredicatePartDTO.getPartAlias().equals("an order and only an order")) {
-                        logger.info("Unable to determine modeling from " + sourcePredicatePartDTO.getUuid());
+                        logger.info("Unable to determine modeling from {}", sourcePredicatePartDTO.getUuid());
                         unableToDetermineModeling = true;
                     }
                     break;
                 } else if (unknownConceptModeling(sourcePredicatePartDTO)){
-                    logger.info("Unable to determine modeling from " + sourcePredicatePartDTO.getUuid());
+                    logger.info("Unable to determine modeling from {}", sourcePredicatePartDTO.getUuid());
                     unableToDetermineModeling = true;
                     return;
                 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/visitor/DroolToElmVisitor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/visitor/DroolToElmVisitor.java
@@ -56,7 +56,7 @@ public class DroolToElmVisitor implements Visitor {
     private DroolPredicateToElmExpressionConverter expressionBodyAdapter;
     private DefinitionConverter definitionAdapter = new DefinitionConverter();
     private LibraryConverter libraryAdapter = new LibraryConverter();
-    private Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(DroolToElmVisitor.class);
     private Map<String, Marker> markers = new HashMap<String, Marker>();
 
     /**
@@ -68,7 +68,6 @@ public class DroolToElmVisitor implements Visitor {
         this.modelBuilder = modelBuilder;
         context = new ElmContext(modelBuilder);
         expressionBodyAdapter = new DroolPredicateToElmExpressionConverter(modelBuilder);
-        logger = LoggerFactory.getLogger(this.getClass());
         markers.put("Expression", MarkerFactory.getMarker("Expression"));
         markers.put("Library", MarkerFactory.getMarker("Library"));
         markers.put("ExpressionDef", MarkerFactory.getMarker("ExpressionDef"));
@@ -79,7 +78,6 @@ public class DroolToElmVisitor implements Visitor {
         this.modelBuilder = modelBuilder;
         context = new ElmContext(modelBuilder);
         expressionBodyAdapter = new DroolPredicateToElmExpressionConverter(modelBuilder);
-        logger = LoggerFactory.getLogger(this.getClass());
     }
 
 
@@ -140,7 +138,7 @@ public class DroolToElmVisitor implements Visitor {
         if (predicate.getPredicatePartDTOs().size() > 0 && !predicate.getPredicateType().equals(CriteriaPredicateType.PredicateGroup)) {
             Expression predicateExpression = expressionBodyAdapter.adapt(predicate, context.libraryBuilder);
             if (predicateExpression == null) {
-                logger.warn(markers.get("Expression"), "Not enough information to generate elm from " + predicate.getUuid());
+                logger.warn(markers.get("Expression"), "Not enough information to generate elm from {}", predicate.getUuid());
             } else {
                 logger.debug(markers.get("Expression"), "pushing Predicate Expression to expression Stack: {}", predicateExpression);
                 context.expressionStack.push(predicateExpression);
@@ -157,7 +155,7 @@ public class DroolToElmVisitor implements Visitor {
             logger.debug(markers.get("ExpressionDef"), "pushing expression reference to reference stack: {}", expressionReferenceConjunctionPair);
             context.referenceStack.push(expressionReferenceConjunctionPair);
         } else {
-            logger.warn(markers.get("ExpressionDef"), "Not enough information to generate elm from " + predicate.getUuid());
+            logger.warn(markers.get("ExpressionDef"), "Not enough information to generate elm from {}", predicate.getUuid());
         }
     }
 
@@ -174,7 +172,7 @@ public class DroolToElmVisitor implements Visitor {
                     logger.debug("No Criteria Met Expression Reference built for conditionRel {}", conditionCriteriaRel.getUuid());
                 }
             } else {
-                logger.warn(markers.get("ExpressionDef"), "Not enough information to generate elm from remaining Expression Reference to build CriteriaMetExpression for condition {}" + conditionCriteriaRel.getUuid());
+                logger.warn(markers.get("ExpressionDef"), "Not enough information to generate elm from remaining Expression Reference to build CriteriaMetExpression for condition {}", conditionCriteriaRel.getUuid());
             }
             logger.debug(markers.get("Library"), "Building Library {}", context.libraryBuilder.getLibraryIdentifier());
             context.buildLibrary();
@@ -220,7 +218,7 @@ public class DroolToElmVisitor implements Visitor {
                     logger.debug("No Criteria Met Expression Reference built for condition {}", conditionDTO.getUuid());
                 }
             } else {
-                logger.warn(markers.get("Library"), "No remaining Expression Reference to build CriteriaMetExpression from condition {}" + conditionDTO.getUuid());
+                logger.warn(markers.get("Library"), "No remaining Expression Reference to build CriteriaMetExpression from condition {}", conditionDTO.getUuid());
             }
             logger.debug(markers.get("Library"), "Building Library {}", context.libraryBuilder.getLibraryIdentifier());
             context.buildLibrary();

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/visitor/ElmToCqlVisitor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/visitor/ElmToCqlVisitor.java
@@ -20,7 +20,7 @@ import com.google.common.base.Strings;
  * @since 2021-04-05
  */
 public class ElmToCqlVisitor extends ElmBaseLibraryVisitor<Void, ElmContext> {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(ElmToCqlVisitor.class);
     private boolean useSpaces = true;
 
     public boolean getUseSpaces() {
@@ -268,7 +268,7 @@ public class ElmToCqlVisitor extends ElmBaseLibraryVisitor<Void, ElmContext> {
     }
 
     private void newConstruct(String section) {
-        logger.debug("Adding new construct: " + section);
+        logger.debug("Adding new construct: {}", section);
         resetIndentLevel();
         newLine();
         addToSection(section);

--- a/tooling/src/main/java/org/opencds/cqf/tooling/dateroller/DataDateRollerOperation.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/dateroller/DataDateRollerOperation.java
@@ -20,7 +20,7 @@ public class DataDateRollerOperation extends Operation {
     public static final String separator = System.getProperty("file.separator");
     public String fhirVersion;
     private IOUtils.Encoding fileEncoding;
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(DataDateRollerOperation.class);
 
     @Override
     public void execute(String[] args) {
@@ -88,7 +88,7 @@ public class DataDateRollerOperation extends Operation {
     }
 
     private void rollDatesInFile(File file) {
-        logger.info("Rolling dates for file: " + file.getAbsolutePath());
+        logger.info("Rolling dates for file: {}", file.getAbsolutePath());
         fileEncoding = IOUtils.getEncoding(file.getName());
 
         String fileContents = IOUtils.getFileContent(file);
@@ -125,7 +125,7 @@ public class DataDateRollerOperation extends Operation {
             }
         }
         else{
-            logger.error(String.format("The file %s was either empty or came back null.", file.getAbsolutePath()));
+            logger.error("The file {} was either empty or came back null.", file.getAbsolutePath());
         }
     }
 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/fhir/api/FileFhirDal.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/fhir/api/FileFhirDal.java
@@ -24,21 +24,19 @@ public class FileFhirDal implements FhirDal {
   protected final String resourceDir;
   protected final EncodingEnum encoding;
   protected final FhirContext fhirContext;
-  private Logger logger;
+  private static final Logger logger = LoggerFactory.getLogger(FileFhirDal.class);
 
 
   public FileFhirDal(String resourceDir){
     this.resourceDir = resourceDir;
     this.encoding = EncodingEnum.JSON;
     this.fhirContext = FhirContext.forR4();
-    this.logger = LoggerFactory.getLogger(this.getClass());
   }
 
   public FileFhirDal(FileFhirPlatformParameters params){
     this.resourceDir = params.resourceDir;
     this.encoding = params.encoding;
     this.fhirContext = params.fhirContext;
-    this.logger = LoggerFactory.getLogger(this.getClass());
   }
 
   @Override

--- a/tooling/src/main/java/org/opencds/cqf/tooling/library/BaseLibraryGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/library/BaseLibraryGenerator.java
@@ -21,8 +21,12 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.tooling.Operation;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class BaseLibraryGenerator<L extends IBaseResource, T extends BaseNarrativeProvider<?>> extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseLibraryGenerator.class);
 
     private T narrativeProvider;
     private FhirContext fhirContext;
@@ -198,7 +202,7 @@ public abstract class BaseLibraryGenerator<L extends IBaseResource, T extends Ba
                 );
 
             if (translator.getErrors().size() > 0) {
-                System.err.println("Translation failed due to errors:");
+                logger.error("Translation failed due to errors:");
                 ArrayList<String> errors = new ArrayList<>();
                 for (CqlCompilerException error : translator.getErrors()) {
                     TrackBack tb = error.getLocator();

--- a/tooling/src/main/java/org/opencds/cqf/tooling/library/LibraryProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/library/LibraryProcessor.java
@@ -32,7 +32,7 @@ import org.opencds.cqf.tooling.utilities.ResourceUtils;
 import ca.uhn.fhir.context.FhirContext;
 
 public class LibraryProcessor extends BaseProcessor {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(LibraryProcessor.class);
     public static final String ResourcePrefix = "library-";   
     public static String getId(String baseId) {
         return ResourcePrefix + baseId;
@@ -57,7 +57,7 @@ public class LibraryProcessor extends BaseProcessor {
         return refreshIgLibraryContent(parentContext, outputEncoding, null, versioned, fhirContext, shouldApplySoftwareSystemStamp);
     }
     public List<String> refreshIgLibraryContent(BaseProcessor parentContext, Encoding outputEncoding, String libraryOutputDirectory, Boolean versioned, FhirContext fhirContext, Boolean shouldApplySoftwareSystemStamp) {
-        System.out.println("Refreshing libraries...");
+        logger.info("Refreshing libraries...");
         // ArrayList<String> refreshedLibraryNames = new ArrayList<String>();
 
         LibraryProcessor libraryProcessor;
@@ -163,7 +163,7 @@ public class LibraryProcessor extends BaseProcessor {
                 sourceLibrary.getParameter().clear();
                 sourceLibrary.getParameter().addAll(info.getParameters());
             } else {
-                logMessage(String.format("No cql info found for ", fileName));
+                logMessage(String.format("No cql info found for %s", fileName));
                 //f.getErrors().add(new ValidationMessage(ValidationMessage.Source.Publisher, ValidationMessage.IssueType.NOTFOUND, "Library", "No cql info found for "+f.getName(), ValidationMessage.IssueSeverity.ERROR));
             }
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
@@ -42,14 +42,14 @@ public class MeasureProcessor extends BaseProcessor {
     public static String getId(String baseId) {
         return ResourcePrefix + baseId;
     }
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MeasureProcessor.class);
     public List<String> refreshIgMeasureContent(BaseProcessor parentContext, Encoding outputEncoding, Boolean versioned, FhirContext fhirContext, String measureToRefreshPath, Boolean shouldApplySoftwareSystemStamp) {
         return refreshIgMeasureContent(parentContext, outputEncoding, null, versioned, fhirContext, measureToRefreshPath, shouldApplySoftwareSystemStamp);
     }
 
     public List<String> refreshIgMeasureContent(BaseProcessor parentContext, Encoding outputEncoding, String measureOutputDirectory, Boolean versioned, FhirContext fhirContext, String measureToRefreshPath, Boolean shouldApplySoftwareSystemStamp) {
 
-        System.out.println("Refreshing measures...");
+        logger.info("Refreshing measures...");
 
         MeasureProcessor measureProcessor;
         switch (fhirContext.getVersion().getVersion()) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/Atlas.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/Atlas.java
@@ -33,8 +33,12 @@ import org.opencds.cqf.tooling.utilities.CanonicalUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Atlas {
+
+    private static final Logger logger = LoggerFactory.getLogger(Atlas.class);
 
     public Atlas() {
         resources = new HashMap<>();
@@ -116,7 +120,7 @@ public class Atlas {
     public void loadPaths(String basePath, String resourcePaths) {
         String[] paths = resourcePaths.split(";");
         for (String path : paths) {
-            System.out.println("Reading " + path + " Conformance Resources");
+            logger.info("Reading {} Conformance Resources", path);
             readConformanceResourcesFromFolder(Paths.get(basePath, path).toString());
         }
     }
@@ -139,7 +143,7 @@ public class Atlas {
             if (!resourcesById.containsKey(id)) {
                 resourcesById.put(id, sd);
             } else {
-                System.out.println("Duplicate url found for: " + sd.getUrl());
+                logger.info("Duplicate url found for: {}", sd.getUrl());
             }
         }
 
@@ -154,11 +158,11 @@ public class Atlas {
                 capabilityStatements.put(id, capabilityStatement);
             }
             else {
-                System.out.println("Duplicate CapabilityStatement with id " + id);
+                logger.info("Duplicate CapabilityStatement with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + capabilityStatement.getUrl());
+            logger.info("Duplicate url found for: {}", capabilityStatement.getUrl());
         }
     }
 
@@ -170,11 +174,11 @@ public class Atlas {
                 compartmentDefinitions.put(id, compartmentDefinition);
             }
             else {
-                System.out.println("Duplicate CompartmentDefinition with id " + id);
+                logger.info("Duplicate CompartmentDefinition with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + compartmentDefinition.getUrl());
+            logger.info("Duplicate url found for: {}", compartmentDefinition.getUrl());
         }
     }
 
@@ -186,11 +190,11 @@ public class Atlas {
                 structureDefinitions.put(id, structureDefinition);
             }
             else {
-                System.out.println("Duplicate StructureDefinition with id " + id);
+                logger.info("Duplicate StructureDefinition with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + structureDefinition.getUrl());
+            logger.info("Duplicate url found for: {}", structureDefinition.getUrl());
         }
     }
 
@@ -202,11 +206,11 @@ public class Atlas {
                 operationDefinitions.put(id, operationDefinition);
             }
             else {
-                System.out.println("Duplicate OperationDefinition with id " + id);
+                logger.info("Duplicate OperationDefinition with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + operationDefinition.getUrl());
+            logger.info("Duplicate url found for: {}", operationDefinition.getUrl());
         }
     }
 
@@ -218,11 +222,11 @@ public class Atlas {
                 searchParameters.put(id, searchParameter);
             }
             else {
-                System.out.println("Duplicate SearchParameter with id " + id);
+                logger.info("Duplicate SearchParameter with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + searchParameter.getUrl());
+            logger.info("Duplicate url found for: {}", searchParameter.getUrl());
         }
     }
 
@@ -234,11 +238,11 @@ public class Atlas {
                 implementationGuides.put(id, implementationGuide);
             }
             else {
-                System.out.println("Duplicate ImplementationGuide with id " + id);
+                logger.info("Duplicate ImplementationGuide with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + implementationGuide.getUrl());
+            logger.info("Duplicate url found for: {}", implementationGuide.getUrl());
         }
     }
 
@@ -250,11 +254,11 @@ public class Atlas {
                 codeSystems.put(id, codeSystem);
             }
             else {
-                System.out.println("Duplicate CodeSystem with id " + id);
+                logger.info("Duplicate CodeSystem with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + codeSystem.getUrl());
+            logger.info("Duplicate url found for: {}", codeSystem.getUrl());
         }
     }
 
@@ -266,11 +270,11 @@ public class Atlas {
                 valueSets.put(id, valueSet);
             }
             else {
-                System.out.println("Duplicate ValueSet with id " + id);
+                logger.info("Duplicate ValueSet with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + valueSet.getUrl());
+            logger.info("Duplicate url found for: {}", valueSet.getUrl());
         }
     }
 
@@ -282,11 +286,11 @@ public class Atlas {
                 conceptMaps.put(id, conceptMap);
             }
             else {
-                System.out.println("Duplicate ConceptMap with id " + id);
+                logger.info("Duplicate ConceptMap with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + conceptMap.getUrl());
+            logger.info("Duplicate url found for: {}", conceptMap.getUrl());
         }
     }
 
@@ -298,11 +302,11 @@ public class Atlas {
                 namingSystems.put(id, namingSystem);
             }
             else {
-                System.out.println("Duplicate NamingSystem with id " + id);
+                logger.info("Duplicate NamingSystem with id {}", id);
             }
         }
         else {
-            System.out.println("Duplicate url found for: " + namingSystem.getUrl());
+            logger.info("Duplicate url found for: {}", namingSystem.getUrl());
         }
     }
 
@@ -338,7 +342,7 @@ public class Atlas {
             indexNamingSystem((NamingSystem)resource);
         }
         else {
-            System.out.println("Resource with id " + resource.getIdElement().toString() + " skipped");
+            logger.info("Resource with id {} skipped", resource.getIdElement());
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/ResourceLoader.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/ResourceLoader.java
@@ -22,8 +22,12 @@ import org.hl7.fhir.r4.model.StructureDefinition;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ResourceLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResourceLoader.class);
 
     public Map<String, StructureDefinition> loadPaths(String basePath, String resourcePaths) {
 
@@ -31,11 +35,11 @@ public class ResourceLoader {
 
         String[] paths = resourcePaths.split(";");
         for (String path : paths) {
-            System.out.println("Reading " + path + " StructureDefinitions");
+            logger.info("Reading {} StructureDefinitions", path);
             resources.addAll(this.readStructureDefFromFolder(Paths.get(basePath, path).toString()));
         }
 
-        System.out.println("Indexing StructureDefinitions by Id");
+        logger.info("Indexing StructureDefinitions by Id");
         return this.indexResources(resources);
     }
 
@@ -56,7 +60,7 @@ public class ResourceLoader {
             if (!resourcesById.containsKey(id)) {
                 resourcesById.put(id, sd);
             } else {
-                System.out.println("Duplicate url found for: " + sd.getUrl());
+                logger.info("Duplicate url found for: {}", sd.getUrl());
             }
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/StructureDefinitionToModelInfo.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/StructureDefinitionToModelInfo.java
@@ -25,12 +25,16 @@ import org.opencds.cqf.tooling.modelinfo.quick.QuickClassInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.quick.QuickModelInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.uscore.USCoreClassInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.uscore.USCoreModelInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 
 public class StructureDefinitionToModelInfo extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(StructureDefinitionToModelInfo.class);
 
     private String inputPath;
     private String resourcePaths;
@@ -229,7 +233,7 @@ public class StructureDefinitionToModelInfo extends Operation {
             String fileName = modelName.toLowerCase() + "-" + "modelinfo" + "-" + modelVersion + ".xml";
             writeOutput(fileName, sw.toString());
         } catch (Exception e) {
-            System.err.println("error" + e.getMessage());
+            logger.error("error: {}", e.getMessage());
             e.printStackTrace();
         }
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRClassInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRClassInfoBuilder.java
@@ -9,8 +9,12 @@ import org.hl7.fhir.r4.model.StructureDefinition;
 import org.hl7.fhir.r4.model.StructureDefinition.StructureDefinitionKind;
 import org.hl7.fhir.r4.model.StructureDefinition.TypeDerivationRule;
 import org.opencds.cqf.tooling.modelinfo.ClassInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FHIRClassInfoBuilder extends ClassInfoBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(FHIRClassInfoBuilder.class);
 
     public FHIRClassInfoBuilder(Map<String, StructureDefinition> structureDefinitions) {
         super(new FHIRClassInfoSettings(), structureDefinitions);
@@ -19,16 +23,16 @@ public class FHIRClassInfoBuilder extends ClassInfoBuilder {
     @Override
     protected void innerBuild() {
         if (!this.settings.useCQLPrimitives) {
-            System.out.println("Building Primitives");
+            logger.info("Building Primitives");
             this.buildFor("FHIR", (x -> x.getKind() == StructureDefinitionKind.PRIMITIVETYPE));
         }
 
-        System.out.println("Building ComplexTypes");
+        logger.info("Building ComplexTypes");
         this.buildFor("FHIR", (x -> (x.getKind() == StructureDefinitionKind.COMPLEXTYPE && (x.getBaseDefinition() == null
                 || !x.getBaseDefinition().equals("http://hl7.org/fhir/StructureDefinition/Extension")))
                 && !x.getUrl().equals("http://hl7.org/fhir/StructureDefinition/elementdefinition-de")));
 
-        System.out.println("Building Resources");
+        logger.info("Building Resources");
         this.buildFor("FHIR", (x -> x.getKind() == StructureDefinitionKind.RESOURCE
                 && (!x.hasDerivation() || x.getDerivation() == TypeDerivationRule.SPECIALIZATION)));
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRModelInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/fhir/FHIRModelInfoBuilder.java
@@ -15,8 +15,12 @@ import org.opencds.cqf.tooling.modelinfo.Atlas;
 import org.opencds.cqf.tooling.modelinfo.ContextInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.ModelInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.SearchInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FHIRModelInfoBuilder extends ModelInfoBuilder {
+
+    private static final Logger logger = LoggerFactory.getLogger(FHIRModelInfoBuilder.class);
     private String fhirHelpersPath;
     private SearchInfoBuilder searchInfoBuilder;
     private ContextInfoBuilder contextInfoBuilder;
@@ -324,7 +328,7 @@ public class FHIRModelInfoBuilder extends ModelInfoBuilder {
             pw.close();
         }
         catch (Exception e) {
-            System.out.println("Unable to write FileHelpers");
+            logger.error("Unable to write FileHelpers");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreModelInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/qicore/QICoreModelInfoBuilder.java
@@ -8,8 +8,11 @@ import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.opencds.cqf.tooling.modelinfo.Atlas;
 import org.opencds.cqf.tooling.modelinfo.ContextInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.ModelInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QICoreModelInfoBuilder extends ModelInfoBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(QICoreModelInfoBuilder.class);
     private String helpersPath;
     private ContextInfoBuilder contextInfoBuilder;
 
@@ -137,7 +140,7 @@ public class QICoreModelInfoBuilder extends ModelInfoBuilder {
             pw.close();
         }
         catch (Exception e) {
-            System.out.println("Unable to write QICoreHelpers");
+            logger.error("Unable to write QICoreHelpers");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreModelInfoBuilder.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/uscore/USCoreModelInfoBuilder.java
@@ -8,8 +8,11 @@ import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.opencds.cqf.tooling.modelinfo.Atlas;
 import org.opencds.cqf.tooling.modelinfo.ContextInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.ModelInfoBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class USCoreModelInfoBuilder extends ModelInfoBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(USCoreModelInfoBuilder.class);
     private String helpersPath;
     private ContextInfoBuilder contextInfoBuilder;
 
@@ -159,7 +162,7 @@ public class USCoreModelInfoBuilder extends ModelInfoBuilder {
             pw.close();
         }
         catch (Exception e) {
-            System.out.println("Unable to write USCoreHelpers");
+            logger.error("Unable to write USCoreHelpers");
         }
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -20,8 +20,13 @@ import org.opencds.cqf.tooling.utilities.IOUtils.Encoding;
 import org.opencds.cqf.tooling.utilities.LogUtils;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IGProcessor extends BaseProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(IGProcessor.class);
+
     public static final String IG_VERSION_REQUIRED = "igVersion required";
 	protected IGBundleProcessor igBundleProcessor;
     protected LibraryProcessor libraryProcessor;
@@ -115,7 +120,7 @@ public class IGProcessor extends BaseProcessor {
                 initializeFromIg(params.rootDir, params.igPath, null);
             }
             catch (Exception e) {
-                logMessage(String.format("Error Refreshing for File "+ params.igPath+": "+e.getMessage(), e));
+                logMessage(String.format("Error Refreshing for File %s: %s", params.igPath, e.getMessage()));
             }
         }
 
@@ -243,7 +248,7 @@ public class IGProcessor extends BaseProcessor {
     private static void checkForDirectory(String igPath, String pathElement) {
         File directory = new File(FilenameUtils.concat(igPath, pathElement));
         if (!directory.exists()) {
-            System.out.println("No directory found by convention for: " + directory.getName());
+            logger.info("No directory found by convention for: {}", directory.getName());
         }
         else {
             // TODO: This is a concept different from "resource directories". It is expected elsewhere (e.g., IOUtils.setupActivityDefinitionPaths)

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/PlanDefinitionProcessor.java
@@ -21,7 +21,7 @@ public class PlanDefinitionProcessor {
     public static final String PlanDefinitionTestGroupName = "plandefinition";
     private LibraryProcessor libraryProcessor;
     private CDSHooksProcessor cdsHooksProcessor;
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(PlanDefinitionProcessor.class);
 
     public PlanDefinitionProcessor(LibraryProcessor libraryProcessor, CDSHooksProcessor cdsHooksProcessor) {
         this.libraryProcessor = libraryProcessor;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/PostBundlesInDirProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/PostBundlesInDirProcessor.java
@@ -10,9 +10,13 @@ import org.opencds.cqf.tooling.utilities.HttpClientUtils;
 import org.opencds.cqf.tooling.utilities.IOUtils.Encoding;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PostBundlesInDirProcessor {
-    
+    private static final Logger logger = LoggerFactory.getLogger(PostBundlesInDirProcessor.class);
+
+
     public enum FHIRVersion {
         FHIR3("fhir3"), FHIR4("fhir4");
 
@@ -64,9 +68,9 @@ public class PostBundlesInDirProcessor {
         if (fhirUri != null && !fhirUri.equals("")) {  
             try {
                 HttpClientUtils.post(fhirUri, bundle, encoding, fhirContext);
-                System.out.println("Resource successfully posted to FHIR server (" + fhirUri + "): " + bundle.getIdElement().getIdPart());
+                logger.info("Resource successfully posted to FHIR server ({}): {}", fhirUri, bundle.getIdElement().getIdPart());
             } catch (Exception e) {
-                System.out.println(bundle.getIdElement().getIdPart() + e);             
+                logger.error("Error occurred for element {}: {}",bundle.getIdElement().getIdPart(), e.getMessage());
             }  
         }
     }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/TestCaseProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/TestCaseProcessor.java
@@ -15,16 +15,20 @@ import org.opencds.cqf.tooling.utilities.LogUtils;
 import org.opencds.cqf.tooling.utilities.ResourceUtils;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestCaseProcessor
 {
+    private static final Logger logger = LoggerFactory.getLogger(TestCaseProcessor.class);
+
     public void refreshTestCases(String path, IOUtils.Encoding encoding, FhirContext fhirContext) {
         refreshTestCases(path, encoding, fhirContext, null);
     }
 
     public void refreshTestCases(String path, IOUtils.Encoding encoding, FhirContext fhirContext, @Nullable List<String> refreshedResourcesNames)
     {
-        System.out.println("Refreshing tests");
+        logger.info("Refreshing tests");
         List<String> resourceTypeTestGroups = IOUtils.getDirectoryPaths(path, false);
 
         for (String group : resourceTypeTestGroups) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
@@ -13,8 +13,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.opencds.cqf.tooling.Operation;
 
 import info.bliki.wiki.model.WikiModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QdmToQiCore extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(QdmToQiCore.class);
 
     private final String[] typeURLS = {
             "Adverse_Event_(QDM)", "Allergy/Intolerance_(QDM)", "Assessment_(QDM)",
@@ -45,7 +49,7 @@ public class QdmToQiCore extends Operation {
             try {
                 url = new URL(fullURL);
             } catch (MalformedURLException e) {
-                System.err.println("Encountered the following malformed URL: " + fullURL);
+                logger.error("Encountered the following malformed URL: {}", fullURL);
                 e.printStackTrace();
                 return;
             }
@@ -54,7 +58,7 @@ public class QdmToQiCore extends Operation {
             try {
                 content = getCleanContent(getPageContent(url));
             } catch (IOException e) {
-                System.err.println("Encountered the following exception while scraping content from " + fullURL + ": " + e.getMessage());
+                logger.error("Encountered the following exception while scraping content from {} : {}", fullURL, e.getMessage());
                 e.printStackTrace();
                 return;
             }
@@ -85,7 +89,7 @@ public class QdmToQiCore extends Operation {
             try {
                 writeOutput(fileName, html);
             } catch (IOException e) {
-                System.err.println("Encountered the following exception while creating file " + fileName + ".html: " + e.getMessage());
+                logger.error("Encountered the following exception while creating file {}.html: {}", fileName, e.getMessage());
                 e.printStackTrace();
                 return;
             }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/questionnaire/QuestionnaireProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/questionnaire/QuestionnaireProcessor.java
@@ -22,7 +22,7 @@ public class QuestionnaireProcessor {
     public static final String QuestionnaireTestGroupName = "questionnaire";
     private LibraryProcessor libraryProcessor;
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(QuestionnaireProcessor.class);
 
     public QuestionnaireProcessor(LibraryProcessor libraryProcessor) {
         this.libraryProcessor = libraryProcessor;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
@@ -20,8 +20,12 @@ import org.jsoup.nodes.Element;
 import org.opencds.cqf.tooling.Operation;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QuickPageGenerator extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuickPageGenerator.class);
 
     // Assuming R4
     private FhirContext context = FhirContext.forR4Cached();
@@ -68,7 +72,7 @@ public class QuickPageGenerator extends Operation {
      */
     private void processQiCoreProfiles() throws IOException, FHIRException {
         for (Map.Entry<String, StructureDefinition> entrySet : atlas.getQicoreProfiles().entrySet()) {
-            System.out.println("Processing the " + entrySet.getKey() + " profile...");
+            logger.info("Processing the {} profile...", entrySet.getKey());
 
             // Initialize HTML page
             HtmlBuilder html = new HtmlBuilder(entrySet.getKey(), atlas);
@@ -207,8 +211,8 @@ public class QuickPageGenerator extends Operation {
                             html.buildRow(mustSupport, isModifier, qicoreExtension, field, card, type, description);
                         }
 
-                        System.out.println(
-                                String.format("Field: %s, Card: %s, Type: %s, Description: %s", field, card, type, description)
+                        logger.info(
+                                "Field: {}, Card: {}, Type: {}, Description: {}", field, card, type, description
                         );
                     }
                     html.buildTableEnd();

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetMeta.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetMeta.java
@@ -13,8 +13,11 @@ import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.ValueSet;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DistributableValueSetMeta {
+    private static final Logger logger = LoggerFactory.getLogger(DistributableValueSetMeta.class);
 
     private String id;
     private String version;
@@ -81,7 +84,7 @@ public class DistributableValueSetMeta {
                 vs.setCompose(tempVs.getCompose());
             } catch (Exception e) {
                 //
-                System.out.println("Error parsing compose for: " + vs.getId());
+                logger.error("Error parsing compose for: {}", vs.getId());
             }
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/CPGMeta.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/CPGMeta.java
@@ -2,11 +2,16 @@ package org.opencds.cqf.tooling.terminology.templateToValueSetGenerator;
 
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Date;
 
 public class CPGMeta {
+
+    private static final Logger logger = LoggerFactory.getLogger(CPGMeta.class);
+
     private String id;
     private String version;
     private String name;
@@ -97,8 +102,8 @@ public class CPGMeta {
                 ValueSet tempVs = fhirContext.newXmlParser().parseResource(ValueSet.class, "<ValueSet>" + compose + "</ValueSet>");
                 vs.setCompose(tempVs.getCompose());
             } catch (Exception e) {
-                System.out.println("An error occurred in the compose for the sheet with id: " + this.id);
-                e.printStackTrace();
+                logger.info("An error occurred in the compose for the sheet with id: {}", this.id);
+                logger.error(e.getMessage());
             }
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/TemplateToValueSetGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/TemplateToValueSetGenerator.java
@@ -25,8 +25,12 @@ import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
 import org.opencds.cqf.tooling.terminology.distributable.OrganizationalMetaData;
 
 import ca.uhn.fhir.context.FhirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TemplateToValueSetGenerator extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(TemplateToValueSetGenerator.class);
 
     private FhirContext fhirContext;
 
@@ -298,7 +302,7 @@ public class TemplateToValueSetGenerator extends Operation {
                     if (cpgMeta.getTitle().equals("only fill this out"))
                         continue;
                 } catch (NullPointerException e) {
-                    System.out.println("cpg instance had null title");
+                    logger.error("cpg instance had null title");
                 }
 
                 vs = cpgMeta.populate(fhirContext, outputVersion);
@@ -322,7 +326,7 @@ public class TemplateToValueSetGenerator extends Operation {
                 }
                 valueSets.add(vs);
             } else {
-                System.out.println("Workbook does NOT contain a sheet named " + entrySet.getKey());
+                logger.info("Workbook does NOT contain a sheet named {}", entrySet.getKey());
             }
         }
         return valueSets;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/Helper.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/Helper.java
@@ -5,13 +5,15 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.opencds.cqf.tooling.terminology.templateToValueSetGenerator.testcase.TestCaseOld;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
 
 public class Helper {
 
-
+    private static final Logger logger = LoggerFactory.getLogger(Helper.class);
 
 
     // Assumption made:
@@ -41,12 +43,12 @@ public class Helper {
         if (ret.contains("FALSE")) return "false";
 
         String[] tmp = ret.split("=");
-        System.out.println(inputCell.getStringCellValue());
+        logger.info(inputCell.getStringCellValue());
         String name = ret.split("=")[0];
         String condition = ret.split(" = ")[1];
 
 
-        System.out.println(String.format("%s RET RET RET", ret));
+        logger.info("{} RET RET RET", ret);
         return name;
     }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/TestCaseGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/templateToValueSetGenerator/testcase/generator/TestCaseGenerator.java
@@ -25,8 +25,13 @@ import org.opencds.cqf.tooling.terminology.templateToValueSetGenerator.testcase.
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestCaseGenerator extends Operation {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestCaseGenerator.class);
+
     private final FhirContext ctx = FhirContext.forR4Cached();
     private final IParser parser = ctx.newJsonParser();
     private final List<GuidanceResponse> guidanceResponses = new ArrayList<>();
@@ -102,7 +107,7 @@ public class TestCaseGenerator extends Operation {
         HashMap<String, String>logicInputCorrelations = buildInputCorrelatedHashmap(logicSheet, true, 5);
 
         for (Map.Entry<String, String> i : logicInputCorrelations.entrySet())
-            System.out.println(i.getKey() + " : " + i.getValue());
+            logger.info("{} : {}", i.getKey(), i.getValue());
 
         sortedLogicSheets = Helper.getSortedSheets(logicWorkbook);
         sortedDictSheets  = Helper.getSortedSheets(dictWorkbook);
@@ -274,7 +279,7 @@ public class TestCaseGenerator extends Operation {
 
     private void output(TestCase testCase) {
         String guidanceResponsePath = outputPath + "/testCase-" + testCase.getId().replace("/", "-").toLowerCase() + ".json";
-        System.out.println(testCase.getId());
+        logger.info(testCase.getId());
 
         if (guidanceResponsePath.contains("="))
             guidanceResponsePath = guidanceResponsePath.replace("=", "");

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -692,7 +692,7 @@ public class IOUtils {
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
                     if (path.toLowerCase().contains("valuesets") || path.toLowerCase().contains("valueset")) {
-                        logger.error("Error reading in Terminology from path: {} \n {}", path, e);
+                        logger.error("Error reading in Terminology from path: {} \n {}", path, e.getMessage());
                     }
                 }
             }
@@ -763,7 +763,7 @@ public class IOUtils {
                     resources.put(path, resource);
                 } catch (Exception e) {
                     if(path.toLowerCase().contains("library")) {
-                        logger.error("Error reading in Library from path: {} \n {}", path, e);
+                        logger.error("Error reading in Library from path: {} \n {}", path, e.getMessage());
                     }
                 }
             }
@@ -813,7 +813,7 @@ public class IOUtils {
                     resources.put(path, resource);
                 } catch (Exception e) {
                     if(path.toLowerCase().contains("measure")) {
-                        logger.error("Error reading in Measure from path: {} \n {}", path, e);
+                        logger.error("Error reading in Measure from path: {} \n {}", path, e.getMessage());
                     }
                 }
             }
@@ -1011,7 +1011,7 @@ public class IOUtils {
                     resources.put(path, IOUtils.readResource(path, fhirContext, true));
                 } catch (Exception e) {
                     if(path.toLowerCase().contains("device")) {
-                        logger.error("Error reading in Device from path: {} \n {}", path, e);
+                        logger.error("Error reading in Device from path: {} \n {}", path, e.getMessage());
                     }
                 }
             }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -312,13 +312,13 @@ public class ResourceUtils {
       }
 
       if (dependencies.size() != valueSetResources.size()) {
-         String message = (dependencies.size() - valueSetResources.size()) + " missing ValueSets: \r\n";
-         dependencies.removeAll(valueSetResources.keySet());
-         for (String valueSetUrl : dependencies) {
-            message += valueSetUrl + " MISSING \r\n";
-         }
-         System.out.println(message);
-         throw new Exception(message);
+        String message = (dependencies.size() - valueSetResources.size()) + " missing ValueSets: \r\n";
+        dependencies.removeAll(valueSetResources.keySet());
+        for (String valueSetUrl : dependencies) {
+          message += valueSetUrl + " MISSING \r\n";
+        }
+        logger.error(message);
+        throw new Exception(message);
       }
       return valueSetResources;
    }
@@ -348,9 +348,9 @@ public class ResourceUtils {
       try {
          elm = getElmFromCql(cqlContentPath);
       } catch (Exception e) {
-         System.out.println("error processing cql: ");
-         System.out.println(e.getMessage());
-         return includedDefs;
+        logger.error("error processing cql: ");
+        logger.error(e.getMessage());
+        return includedDefs;
       }
 
       if (elm.getIncludes() != null && !elm.getIncludes().getDef().isEmpty()) {
@@ -365,8 +365,8 @@ public class ResourceUtils {
       try {
          elm = getElmFromCql(cqlContentPath);
       } catch (Exception e) {
-         System.out.println("error translating cql: ");
-         return valueSetDefs;
+        logger.error("error translating cql: ");
+        return valueSetDefs;
       }
       if (elm.getValueSets() != null && !elm.getValueSets().getDef().isEmpty()) {
          valueSetDefs.addAll(elm.getValueSets().getDef());

--- a/tooling/src/main/java/org/opencds/cqf/tooling/vmrToFhir/VmrToFhirTransformer.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/vmrToFhir/VmrToFhirTransformer.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  */
 public class VmrToFhirTransformer {
     private static final String ConditionClinicalStatusCodesUrl = "http://terminology.hl7.org/CodeSystem/condition-clinical";
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(VmrToFhirTransformer.class);
     private Patient patient = new Patient();
 
     /**
@@ -458,7 +458,7 @@ public class VmrToFhirTransformer {
                 return Date.from(zdt.toInstant());
 
             } catch (DateTimeParseException dtpe) {
-                logger.debug("Unable to parse DateTime from: " + operand);
+                logger.debug("Unable to parse DateTime from: {}", operand);
                 return null;
             }
         }

--- a/tooling/src/test/java/org/opencds/cqf/tooling/fhir/api/FileFhirDalTest.java
+++ b/tooling/src/test/java/org/opencds/cqf/tooling/fhir/api/FileFhirDalTest.java
@@ -25,7 +25,7 @@ public class FileFhirDalTest implements CqfmSoftwareSystemTest {
   private FileFhirDal dal;
   private Patient patient;
   private final String resourceDir = "target/FileFhirDalTest";
-  private Logger logger;
+  private static final Logger logger = LoggerFactory.getLogger(FileFhirDalTest.class);
 
   public FileFhirDalTest() {
     FileFhirPlatformParameters platformParams = new FileFhirPlatformParameters();
@@ -38,8 +38,6 @@ public class FileFhirDalTest implements CqfmSoftwareSystemTest {
 
     this.patient = (Patient) new Patient().setId("TestPatient");
     this.patient.setId(this.patient.getIdElement().withResourceType("Patient"));
-
-    this.logger = LoggerFactory.getLogger(this.getClass());
   }
 
   @BeforeClass

--- a/tooling/src/test/java/org/opencds/cqf/tooling/npm/NpmPackageManagerTests.java
+++ b/tooling/src/test/java/org/opencds/cqf/tooling/npm/NpmPackageManagerTests.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
 
-    private Logger logger = LoggerFactory.getLogger(NpmPackageManagerTests.class);
+    private static final Logger logger = LoggerFactory.getLogger(NpmPackageManagerTests.class);
     /*
     NOTE: This test depends on the dev package cache for the [sample-ig](https://github.com/FHIR/sample-ig)
     Running the IG publisher on a clone of this IG locally will create and cache the package


### PR DESCRIPTION
**Description**

Various parts of the tooling log errors / warnings to System.out instead of a logging framework. This makes it difficult to redirect logging to a file or to distinguish errors from the actual output.

This change routes output to the SLF4J logging framework, except for in cases where the outputs are required by the CLI.
It also cleans up log message formatting.

- Github Issue:  https://github.com/cqframework/cqf-tooling/issues/262
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
