### PR TITLE
Add helper method for platform independent file path building

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/DTProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/DTProcessor.java
@@ -33,6 +33,7 @@ import org.hl7.fhir.r4.model.TriggerDefinition;
 import org.hl7.fhir.r4.model.UsageContext;
 import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 
@@ -608,7 +609,7 @@ public class DTProcessor extends Operation {
 
     private void writeLibraries(String outputPath) {
         if (libraries != null && libraries.size() > 0) {
-            String outputFilePath = outputPath + File.separator + "input" + File.separator + "resources" + File.separator + "library";
+            String outputFilePath = IOUtils.concatFilePath(outputPath, "input", "resources", "library");
             ensurePath(outputFilePath);
 
             for (Library library : libraries.values()) {
@@ -620,8 +621,9 @@ public class DTProcessor extends Operation {
     private void writeLibraryCQL(String outputPath) {
         if (libraryCQL != null && libraryCQL.size() > 0) {
             for (Map.Entry<String, StringBuilder> entry : libraryCQL.entrySet()) {
-                String outputDirectoryPath = outputPath + File.separator + "input" + File.separator + "cql";
-                String outputFilePath = outputDirectoryPath + File.separator + entry.getKey() + ".cql";
+                String outputDirectoryPath = IOUtils.concatFilePath(outputPath, "input", "cql");
+                String outputFilePath = IOUtils.concatFilePath(outputDirectoryPath,
+                        entry.getKey() + ".cql");
                 ensurePath(outputDirectoryPath);
 
                 try (FileOutputStream writer = new FileOutputStream(outputFilePath)) {
@@ -639,7 +641,8 @@ public class DTProcessor extends Operation {
     private void writePlanDefinitions(String outputPath) {
         if (planDefinitions != null && planDefinitions.size() > 0) {
             for (PlanDefinition planDefinition : planDefinitions.values()) {
-                String outputFilePath = outputPath + File.separator + "input" + File.separator + "resources" + File.separator + "plandefinition";
+                String outputFilePath = IOUtils.concatFilePath(outputPath,
+                        "input", "resources", "plandefinition");
                 ensurePath(outputFilePath);
                 writeResource(outputFilePath, planDefinition);
             }
@@ -648,7 +651,8 @@ public class DTProcessor extends Operation {
 
     /* Write Methods */
     public void writeResource(String path, Resource resource) {
-        String outputFilePath = path + File.separator + resource.getResourceType().toString().toLowerCase() + "-" + resource.getIdElement().getIdPart() + "." + encoding;
+        String outputFilePath = IOUtils.concatFilePath(path,
+                resource.getResourceType().toString().toLowerCase() + "-" + resource.getIdElement().getIdPart() + "." + encoding);
         try (FileOutputStream writer = new FileOutputStream(outputFilePath)) {
             writer.write(
                     encoding.equals("json")
@@ -681,7 +685,8 @@ public class DTProcessor extends Operation {
     }
 
     public void writePlanDefinitionIndex(String outputPath) {
-        String outputFilePath = outputPath + File.separator + "input" + File.separator + "pagecontent"+ File.separator + "PlanDefinitionIndex.md";
+        String outputFilePath = IOUtils.concatFilePath(outputPath,
+                "input", "pagecontent", "PlanDefinitionIndex.md");
         ensurePath(outputFilePath);
 
         try (FileOutputStream writer = new FileOutputStream(outputFilePath)) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/Processor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/acceleratorkit/Processor.java
@@ -40,6 +40,7 @@ import org.hl7.fhir.r4.model.UsageContext;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 
@@ -2574,7 +2575,8 @@ public class Processor extends Operation {
 
     /* Write Methods */
     public void writeResource(String path, Resource resource) {
-        String outputFilePath = path + "/" + resource.getResourceType().toString().toLowerCase() + "-" + resource.getIdElement().getIdPart() + "." + encoding;
+        String outputFilePath = IOUtils.concatFilePath(path,
+                resource.getResourceType().toString().toLowerCase() + "-" + resource.getIdElement().getIdPart() + "." + encoding);
         try (FileOutputStream writer = new FileOutputStream(outputFilePath)) {
             writer.write(
                 encoding.equals("json")
@@ -2976,7 +2978,8 @@ public class Processor extends Operation {
         }
 
         ensureCqlPath(scopePath);
-        try (FileOutputStream writer = new FileOutputStream(getCqlPath(scopePath) + "/" + scope + "Concepts.cql")) {
+        try (FileOutputStream writer = new FileOutputStream(
+                IOUtils.concatFilePath(getCqlPath(scopePath),scope + "Concepts.cql"))) {
             writer.write(sb.toString().getBytes());
             writer.flush();
         }
@@ -3420,7 +3423,8 @@ public class Processor extends Operation {
         }
 
         ensureCqlPath(scopePath);
-        try (FileOutputStream writer = new FileOutputStream(getCqlPath(scopePath) + "/" + scope + (context.equals("Encounter") ? "Contact" : "") + "DataElements.cql")) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getCqlPath(scopePath),
+                scope + (context.equals("Encounter") ? "Contact" : "") + "DataElements.cql"))) {
             writer.write(sb.toString().getBytes());
             writer.flush();
         }
@@ -3429,7 +3433,8 @@ public class Processor extends Operation {
             throw new IllegalArgumentException("Error writing concepts library source");
         }
 
-        try (FileOutputStream writer = new FileOutputStream(getCqlPath(scopePath) + "/" + scope + "DataElementsByActivity.md")) {
+        try (FileOutputStream writer = new FileOutputStream(
+                IOUtils.concatFilePath(getCqlPath(scopePath), scope + "DataElementsByActivity.md"))) {
             writer.write(activityIndex.toString().getBytes());
             writer.flush();
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/common/BaseCqfmSoftwareSystemHelper.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/common/BaseCqfmSoftwareSystemHelper.java
@@ -3,12 +3,12 @@ package org.opencds.cqf.tooling.common;
 import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.opencds.cqf.tooling.utilities.LogUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 
 
 public abstract class BaseCqfmSoftwareSystemHelper {
-    public static final String separator = System.getProperty("file.separator");
     private String rootDir;
     protected String getRootDir() {
         return this.rootDir;
@@ -18,7 +18,8 @@ public abstract class BaseCqfmSoftwareSystemHelper {
     private static String cqfToolingDeviceName = "cqf-tooling";
 //    private static String cqfToolingDeviceReferenceID = "#" + cqfToolingDeviceName;
     private static String cqfmSoftwareSystemExtensionUrl = "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem";
-    protected static String devicePath = separator + "input" + separator + "resources" + separator + "device";
+    protected static String devicePath = IOUtils.concatFilePath(File.separator,
+            "input", "resources", "device");
 
     protected String getCqfToolingDeviceName() { return cqfToolingDeviceName; }
 //    protected String getCqfToolingDeviceReferenceID() { return cqfToolingDeviceReferenceID; }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/common/JarEnabledCustomThymeleafNarrativeGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/common/JarEnabledCustomThymeleafNarrativeGenerator.java
@@ -72,7 +72,7 @@ public class JarEnabledCustomThymeleafNarrativeGenerator extends ThymeleafNarrat
 			String cpName = name.substring("classpath:".length());
 			try (InputStream resource =  Thread.currentThread().getContextClassLoader().getResourceAsStream(cpName)) {
 				if (resource == null) {
-					try (InputStream resource2 =Thread.currentThread().getContextClassLoader().getResourceAsStream("/" + cpName)) {
+					try (InputStream resource2 =Thread.currentThread().getContextClassLoader().getResourceAsStream(File.separator + cpName)) {
 						if (resource2 == null) {
 							throw new IOException("Can not find '" + cpName + "' on classpath");
 						}

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/DroolCqlGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/DroolCqlGenerator.java
@@ -24,6 +24,7 @@ import org.opencds.cqf.tooling.cql_generation.drool.visitor.DroolToElmVisitor;
 import org.opencds.cqf.tooling.cql_generation.drool.visitor.DroolToElmVisitor.CQLTYPES;
 import org.opencds.cqf.tooling.cql_generation.drool.visitor.ElmToCqlVisitor;
 import org.opencds.cqf.tooling.cql_generation.drool.visitor.Visitor;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +116,8 @@ public class DroolCqlGenerator implements CqlGenerator {
                 VersionedIdentifier vi = new VersionedIdentifier();
                 vi.setId(getIdFromSource(cql));
                 vi.setVersion(getVersionFromSource(cql));
-                File outputFile = new File(outpuDirectory.getAbsolutePath() + "/" + vi.getId() + "-" + vi.getVersion() + ".cql");
+                File outputFile = new File(IOUtils.concatFilePath(outpuDirectory.getAbsolutePath(),
+                        vi.getId() + "-" + vi.getVersion() + ".cql"));
                 IOUtil.writeToFile(outputFile, cql);
             } else {
                 throw new IllegalArgumentException("Output directory is not a directory: " + outpuDirectory.getAbsolutePath());
@@ -130,7 +132,8 @@ public class DroolCqlGenerator implements CqlGenerator {
             try {
                 String elm = serializer.convertToXml(modelBuilder.of.createLibrary(entry.getValue()), serializer.getJaxbContext());
                 if (outpuDirectory.isDirectory()) {
-                    File outputFile = new File(outpuDirectory.getAbsolutePath() + "/" + entry.getKey() + ".xml");
+                    File outputFile = new File(IOUtils.concatFilePath(outpuDirectory.getAbsolutePath(),
+                            entry.getKey() + ".xml"));
                     IOUtil.writeToFile(outputFile, elm);
                 } else {
                     throw new IllegalArgumentException("Output directory is not a directory: " + outpuDirectory.getAbsolutePath());

--- a/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/visitor/HtmlFileVisitor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/cql_generation/drool/visitor/HtmlFileVisitor.java
@@ -19,6 +19,7 @@ import org.cdsframework.dto.DataInputNodeDTO;
 import org.cdsframework.dto.OpenCdsConceptDTO;
 import org.opencds.cqf.tooling.cql_generation.IOUtil;
 import org.opencds.cqf.tooling.cql_generation.context.ElmContext;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 /**
  * Generates html files from an RCKMS Drool Object graph.
@@ -114,8 +115,7 @@ public class HtmlFileVisitor implements Visitor {
     @Override
     public ElmContext visit(List<ConditionDTO> rootNode) {
         htmlStrings.entrySet().stream().forEach(entry -> {
-            // Dont like this concat
-            String filePath = outputDirectoryPath.concat("/" + entry.getKey() + ".html");
+            String filePath = IOUtils.concatFilePath(outputDirectoryPath, entry.getKey() + ".html");
             File file = new File(filePath);
             String content = "<html><head><title>" + entry.getKey() + "</title></head><body><p>" + entry.getValue()
                     + "</p></body></html>";

--- a/tooling/src/main/java/org/opencds/cqf/tooling/dateroller/DataDateRollerOperation.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/dateroller/DataDateRollerOperation.java
@@ -17,7 +17,6 @@ import java.util.Locale;
 
 public class DataDateRollerOperation extends Operation {
     private FhirContext fhirContext;
-    public static final String separator = System.getProperty("file.separator");
     public String fhirVersion;
     private IOUtils.Encoding fileEncoding;
     private Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/tooling/src/main/java/org/opencds/cqf/tooling/fhir/api/FileFhirDal.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/fhir/api/FileFhirDal.java
@@ -12,6 +12,7 @@ import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.opencds.cqf.tooling.parameter.FileFhirPlatformParameters;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ public class FileFhirDal implements FhirDal {
     if (resourceTypeDefined(resource)){
 
       //ensure resource type directory exists
-      String typePath = this.resourceDir + "/" + resource.getIdElement().getResourceType();
+      String typePath = IOUtils.concatFilePath(this.resourceDir, resource.getIdElement().getResourceType());
       String path = getPath(resource);
 
       File typeDir = new File(typePath);
@@ -129,11 +130,13 @@ public class FileFhirDal implements FhirDal {
   }
 
   private String getPath(IBaseResource resource){
-    return this.resourceDir + "/" + resource.getIdElement().getResourceType() + "/" + resource.getIdElement().getIdPart() + "." + this.encoding.toString();
+    return IOUtils.concatFilePath(this.resourceDir, resource.getIdElement().getResourceType(),
+            resource.getIdElement().getIdPart() + "." + this.encoding.toString());
   }
 
   private String getPath(IIdType id){
-    return this.resourceDir + "/" + id.getResourceType() + "/" + id.getIdPart() + "." + this.encoding.toString();
+    return IOUtils.concatFilePath(this.resourceDir, id.getResourceType(),
+            id.getIdPart() + "." + this.encoding.toString());
   }
 
   private boolean resourceTypeDefined(IBaseResource resource){

--- a/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/StructureDefinitionToModelInfo.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/modelinfo/StructureDefinitionToModelInfo.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.tooling.modelinfo.quick.QuickClassInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.quick.QuickModelInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.uscore.USCoreClassInfoBuilder;
 import org.opencds.cqf.tooling.modelinfo.uscore.USCoreModelInfoBuilder;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -162,7 +163,8 @@ public class StructureDefinitionToModelInfo extends Operation {
             Map<String, TypeInfo> typeInfos = ciBuilder.build();
             ciBuilder.afterBuild();
 
-            String fhirHelpersPath = this.getOutputPath() + "/" + modelName + "Helpers-" + modelVersion + ".cql";
+            String fhirHelpersPath = IOUtils.concatFilePath(this.getOutputPath(),
+                    modelName + "Helpers-" + modelVersion + ".cql");
             miBuilder = new FHIRModelInfoBuilder(modelVersion, typeInfos, atlas, fhirHelpersPath);
             mi = miBuilder.build();
         }
@@ -173,7 +175,8 @@ public class StructureDefinitionToModelInfo extends Operation {
             Map<String, TypeInfo> typeInfos = ciBuilder.build();
             ciBuilder.afterBuild();
 
-            String helpersPath = this.getOutputPath() + "/" + modelName + "Helpers-" + modelVersion + ".cql";
+            String helpersPath = IOUtils.concatFilePath(this.getOutputPath(),
+                    modelName + "Helpers-" + modelVersion + ".cql");
             miBuilder = new USCoreModelInfoBuilder(modelVersion, typeInfos, atlas, helpersPath);
             mi = miBuilder.build();
         }
@@ -184,7 +187,8 @@ public class StructureDefinitionToModelInfo extends Operation {
             Map<String, TypeInfo> typeInfos = ciBuilder.build();
             ciBuilder.afterBuild();
 
-            String helpersPath = this.getOutputPath() + "/" + modelName + "Helpers-" + modelVersion + ".cql";
+            String helpersPath = IOUtils.concatFilePath(this.getOutputPath(),
+                    modelName + "Helpers-" + modelVersion + ".cql");
             miBuilder = new QICoreModelInfoBuilder(modelVersion, typeInfos, atlas, helpersPath);
             mi = miBuilder.build();
         }
@@ -235,7 +239,7 @@ public class StructureDefinitionToModelInfo extends Operation {
     }
 
     private void writeOutput(String fileName, String content) throws IOException {
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + fileName)) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(), fileName))) {
             writer.write(content.getBytes());
             writer.flush();
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/BundleResources.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -192,7 +193,7 @@ public class BundleResources extends Operation {
     public void output(IBaseResource resource, FhirContext context) {
         String fileNameBase = getOutputPath() + getOutputPath().substring(getOutputPath().lastIndexOf(File.separator));
         if (bundleId != null && !bundleId.isEmpty()) {
-            fileNameBase = getOutputPath() + File.separator + bundleId;
+            fileNameBase = IOUtils.concatFilePath(getOutputPath(), bundleId);
         }
 
         try (FileOutputStream writer = new FileOutputStream(fileNameBase + "-bundle." + encoding)) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/BundleToResources.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/BundleToResources.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
@@ -163,7 +164,9 @@ public class BundleToResources extends Operation {
     
     // Output
     public void output(IBaseResource resource, FhirContext context) {
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + resource.getIdElement().getResourceType() + "-" + resource.getIdElement().getIdPart() + "." + encoding)) {
+        try (FileOutputStream writer = new FileOutputStream(
+                IOUtils.concatFilePath(getOutputPath(),
+                        resource.getIdElement().getResourceType() + "-" + resource.getIdElement().getIdPart() + "." + encoding))) {
             writer.write(
                 encoding.equals("json")
                     ? context.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource).getBytes()

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/IgBundler.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/IgBundler.java
@@ -35,6 +35,7 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -157,12 +158,12 @@ public class IgBundler extends Operation
                 if (resources.isJsonArray()) {
                     for (final JsonElement path : resources.getAsJsonArray()) {
                         if (path.isJsonPrimitive()) {
-                            resourcePaths.add(pathToIg + "/" + path.getAsString());
+                            resourcePaths.add(IOUtils.concatFilePath(pathToIg, path.getAsString()));
                             outputBundles.put(path.getAsString(), null);
                         }
                     }
                 } else {
-                    resourcePaths.add(pathToIg + "/" + resources.getAsString());
+                    resourcePaths.add(IOUtils.concatFilePath(pathToIg, resources.getAsString()));
                 }
             }
         }
@@ -247,7 +248,7 @@ public class IgBundler extends Operation
     private void outputBundles() {
         for (final Map.Entry<String, IBaseResource> set : outputBundles.entrySet()) {
             try (FileOutputStream writer = new FileOutputStream(
-                    getOutputPath() + "/" + set.getKey() + "." + encoding)) {
+                    IOUtils.concatFilePath(getOutputPath(), set.getKey() + "." + encoding))) {
                 writer.write(encoding.equals("json")
                         ? jsonParser.setPrettyPrint(true).encodeResourceToString(set.getValue()).getBytes()
                         : xmlParser.setPrettyPrint(true).encodeResourceToString(set.getValue()).getBytes());

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/ProfilesToSpreadsheet.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/ProfilesToSpreadsheet.java
@@ -7,6 +7,7 @@ import org.apache.poi.xssf.usermodel.*;
 import org.opencds.cqf.tooling.acceleratorkit.StructureDefinitionBindingObject;
 import org.opencds.cqf.tooling.acceleratorkit.StructureDefinitionElementBindingVisitor;
 import org.opencds.cqf.tooling.terminology.SpreadsheetCreatorHelper;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.opencds.cqf.tooling.utilities.ModelCanonicalAtlasCreator;
 
 
@@ -83,7 +84,8 @@ public class ProfilesToSpreadsheet extends StructureDefinitionToSpreadsheetBase 
         bindingObjects.forEach((bindingObject) -> {
             addBindingObjectRowDataToCurrentSheet(firstSheet, rowCount.getAndAccumulate(1, ibo), bindingObject);
         });
-        SpreadsheetCreatorHelper.writeSpreadSheet(workBook, getOutputPath() + separator + modelName + modelVersion + ".xlsx");
+        SpreadsheetCreatorHelper.writeSpreadSheet(workBook,
+                IOUtils.concatFilePath(getOutputPath(), modelName + modelVersion + ".xlsx"));
     }
 
     private List<String> createHeaderNameList() {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/QICoreElementsToSpreadsheet.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/QICoreElementsToSpreadsheet.java
@@ -8,6 +8,7 @@ import org.apache.poi.xssf.usermodel.*;
 import org.opencds.cqf.tooling.acceleratorkit.StructureDefinitionElementObject;
 import org.opencds.cqf.tooling.acceleratorkit.StructureDefinitionElementVisitor;
 import org.opencds.cqf.tooling.terminology.SpreadsheetCreatorHelper;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 import org.opencds.cqf.tooling.utilities.ModelCanonicalAtlasCreator;
 
 import java.util.ArrayList;
@@ -91,7 +92,8 @@ public class QICoreElementsToSpreadsheet extends StructureDefinitionToSpreadshee
         });
         firstSheet.setColumnWidth(ConstraintColumn, ConstraintColumnWidth);
 //        firstSheet.autoSizeColumn(ConstraintColumn);
-        SpreadsheetCreatorHelper.writeSpreadSheet(workBook, getOutputPath() + separator + modelName + modelVersion + ".xlsx");
+        SpreadsheetCreatorHelper.writeSpreadSheet(workBook,
+                IOUtils.concatFilePath(getOutputPath(), modelName + modelVersion + ".xlsx"));
     }
 
     private List<String> createHeaderNameList() {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/StructureDefinitionToSpreadsheetBase.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/StructureDefinitionToSpreadsheetBase.java
@@ -17,7 +17,6 @@ public abstract class StructureDefinitionToSpreadsheetBase extends Operation {
     protected CreationHelper helper;
     protected XSSFCellStyle linkStyle;
 
-    public static final String separator = System.getProperty("file.separator");
     protected boolean isParameterListComplete() {
         if (null == inputPath || inputPath.length() < 1 ||
                 null == modelName || modelName.length() < 1 ||

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/VmrToFhirProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/VmrToFhirProcessor.java
@@ -58,7 +58,7 @@ public class VmrToFhirProcessor {
 
     private static void writeOutput(String fhirOutputPath, FhirContext context, Patient patient, List<IAnyResource> resources,
             BundleBuilder bundleBuilder) {
-        File outputDirectory = new File(fhirOutputPath + "/" + patient.getIdElement().getIdPart());
+        File outputDirectory = new File(IOUtils.concatFilePath(fhirOutputPath, patient.getIdElement().getIdPart()));
         if (!outputDirectory.isDirectory()) {
             outputDirectory.mkdirs();
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/qdm/QdmToQiCore.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import info.bliki.wiki.model.WikiModel;
 
@@ -172,7 +173,8 @@ public class QdmToQiCore extends Operation {
     }
 
     private void writeOutput(String fileName, String content) throws IOException {
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + fileName + ".html")) {
+        try (FileOutputStream writer = new FileOutputStream(
+                IOUtils.concatFilePath(getOutputPath(),fileName + ".html"))) {
             writer.write(content.getBytes());
             writer.flush();
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/quick/QuickPageGenerator.java
@@ -18,6 +18,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 
@@ -491,7 +492,7 @@ public class QuickPageGenerator extends Operation {
      * @throws IOException
      */
     private void writeHtmlFile(String fileName, String html) throws IOException {
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + fileName)) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(), fileName))) {
             writer.write(html.getBytes());
             writer.flush();
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/FlatMultiValueSetGeneratorBase.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/FlatMultiValueSetGeneratorBase.java
@@ -20,6 +20,7 @@ import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -242,7 +243,7 @@ public abstract class FlatMultiValueSetGeneratorBase extends Operation {
                 ? FhirContext.forDstu3Cached().newJsonParser()
                 : FhirContext.forDstu3Cached().newXmlParser();
 
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + fileName)) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(), fileName))) {
             writer.write(parser.setPrettyPrint(true).encodeResourceToString(vs).getBytes());
             writer.flush();
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/RCKMSJurisdictionsGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/RCKMSJurisdictionsGenerator.java
@@ -12,6 +12,7 @@ import org.hl7.fhir.dstu3.model.CodeSystem;
 import org.hl7.fhir.dstu3.model.CodeType;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -78,7 +79,7 @@ public class RCKMSJurisdictionsGenerator extends Operation {
                         : encoding.toLowerCase().startsWith("j")
                                 ? FhirContext.forDstu3Cached().newJsonParser()
                                 : FhirContext.forDstu3Cached().newXmlParser();
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + fileName)) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(), fileName))) {
             writer.write(parser.setPrettyPrint(true).encodeResourceToString(cs).getBytes());
             writer.flush();
         } catch (IOException e) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/SpreadsheetHelper.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/SpreadsheetHelper.java
@@ -14,6 +14,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 public class SpreadsheetHelper {
 
@@ -164,7 +165,7 @@ public class SpreadsheetHelper {
                         : encoding.toLowerCase().startsWith("j")
                         ? FhirContext.forDstu3Cached().newJsonParser()
                         : FhirContext.forDstu3Cached().newXmlParser();
-        try (FileOutputStream writer = new FileOutputStream(outputPath + "/" + fileName)) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(outputPath, fileName))) {
             writer.write(parser.setPrettyPrint(true).encodeResourceToString(vs).getBytes());
             writer.flush();
         } catch (IOException e) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/SpreadsheetToCQLOperation.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/SpreadsheetToCQLOperation.java
@@ -13,6 +13,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellReference;
 import org.cqframework.cql.cql2elm.StringEscapeUtils;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 public class SpreadsheetToCQLOperation extends Operation {
 
@@ -138,7 +139,7 @@ public class SpreadsheetToCQLOperation extends Operation {
             result.append(System.lineSeparator());
         }
 
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + File.separator + spreadsheetName + ".cql")) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(),spreadsheetName + ".cql"))) {
             writer.write(result.toString().getBytes());
             writer.flush();
         } catch (IOException e) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/VSACValueSetGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/VSACValueSetGenerator.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.fhir.dstu3.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -297,7 +298,7 @@ public class VSACValueSetGenerator extends Operation {
                         : encoding.toLowerCase().startsWith("j")
                                 ? FhirContext.forDstu3Cached().newJsonParser()
                                 : FhirContext.forDstu3Cached().newXmlParser();
-        try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + fileName)) {
+        try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(), fileName))) {
             writer.write(parser.setPrettyPrint(true).encodeResourceToString(vs).getBytes());
             writer.flush();
         } catch (IOException e) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetGenerator.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/distributable/DistributableValueSetGenerator.java
@@ -1,22 +1,18 @@
 package org.opencds.cqf.tooling.terminology.distributable;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
+import ca.uhn.fhir.context.FhirContext;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.tooling.Operation;
 import org.opencds.cqf.tooling.terminology.SpreadsheetHelper;
+import org.opencds.cqf.tooling.utilities.IOUtils;
 
-import ca.uhn.fhir.context.FhirContext;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.*;
 
 public class DistributableValueSetGenerator extends Operation {
 
@@ -281,7 +277,8 @@ public class DistributableValueSetGenerator extends Operation {
 
     private void output(List<ValueSet> valueSets) {
         for (ValueSet valueSet : valueSets) {
-            try (FileOutputStream writer = new FileOutputStream(getOutputPath() + "/" + "valueset-" + valueSet.getId() + "." + encoding)) {
+            try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(getOutputPath(),
+                    "valueset-" + valueSet.getId() + "." + encoding))) {
                 writer.write(
                         encoding.equals("json")
                                 ? fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(valueSet).getBytes()

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/IOUtils.java
@@ -1035,4 +1035,11 @@ public class IOUtils {
         return false;
     }
 
+    public static String concatFilePath(String basePath, String... pathsToAppend) {
+        String filePath = basePath;
+        for (String pathToAppend: pathsToAppend) {
+            filePath = FilenameUtils.concat(filePath, pathToAppend);
+        }
+        return filePath;
+    }
 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/ResourceUtils.java
@@ -174,7 +174,7 @@ public class ResourceUtils {
                   String name = relatedArtifact.getResource().getReference().split("Library/")[1];
                   dependencyLibraryName = IOUtils.formatFileName(name.split("\\|")[0], encoding, fhirContext);
                }
-               String dependencyLibraryPath = FilenameUtils.concat(directoryPath, prefix + dependencyLibraryName);
+               String dependencyLibraryPath = IOUtils.concatFilePath(directoryPath, prefix + dependencyLibraryName);
                IOUtils.putAllInListIfAbsent(getStu3DepLibraryPaths(dependencyLibraryPath, fhirContext, encoding, versioned), paths);
                IOUtils.putInListIfAbsent(dependencyLibraryPath, paths);
             }
@@ -213,7 +213,7 @@ public class ResourceUtils {
                   String name = relatedArtifact.getResource().split("Library/")[1];
                   dependencyLibraryName = IOUtils.formatFileName(name.split("\\|")[0], encoding, fhirContext);
                }
-               String dependencyLibraryPath = FilenameUtils.concat(directoryPath, prefix + dependencyLibraryName);
+               String dependencyLibraryPath = IOUtils.concatFilePath(directoryPath, prefix + dependencyLibraryName);
                IOUtils.putInListIfAbsent(dependencyLibraryPath, paths);
             }
          }
@@ -375,7 +375,7 @@ public class ResourceUtils {
    }
 
    public static CqlTranslatorOptions getTranslatorOptions(String folder) {
-      String optionsFileName = folder + File.separator + "cql-options.json";
+      String optionsFileName = IOUtils.concatFilePath(folder,"cql-options.json");
       CqlTranslatorOptions options;
       File file = new File(optionsFileName);
       if (file.exists()) {
@@ -846,7 +846,8 @@ public class ResourceUtils {
    }
 
    public static void outputResource(IBaseResource resource, String encoding, FhirContext context, String outputPath) {
-      try (FileOutputStream writer = new FileOutputStream(outputPath + "/" + resource.getIdElement().getResourceType() + "-" + resource.getIdElement().getIdPart() + "." + encoding)) {
+      try (FileOutputStream writer = new FileOutputStream(IOUtils.concatFilePath(outputPath,
+              resource.getIdElement().getResourceType() + "-" + resource.getIdElement().getIdPart() + "." + encoding))) {
          writer.write(
                  encoding.equals("json")
                          ? context.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource).getBytes()
@@ -860,7 +861,8 @@ public class ResourceUtils {
    }
 
    public static void outputResourceByName(IBaseResource resource, String encoding, FhirContext context, String outputPath, String name) {
-      try (FileOutputStream writer = new FileOutputStream(outputPath + "/" + name + "." + encoding)) {
+      try (FileOutputStream writer = new FileOutputStream(
+              IOUtils.concatFilePath(outputPath, name + "." + encoding))) {
          writer.write(
                  encoding.equals("json")
                          ? context.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource).getBytes()

--- a/tooling/src/test/java/org/opencds/cqf/tooling/utilities/IOUtilsTests.java
+++ b/tooling/src/test/java/org/opencds/cqf/tooling/utilities/IOUtilsTests.java
@@ -1,0 +1,18 @@
+package org.opencds.cqf.tooling.utilities;
+
+import static org.testng.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.File;
+
+public class IOUtilsTests {
+
+    @Test
+    public void TestConcatFilePaths() {
+        String basePath = "basePath";
+        String result = IOUtils.concatFilePath(basePath, "input", "resources", "library");
+        String expected = basePath + File.separator + "input" + File.separator + "resources" + File.separator + "library";
+        assertEquals(result, expected);
+    }
+}


### PR DESCRIPTION
Throughout the project "/" is used as a delimiter for file paths. This is specific to Linux/Mac OS. This PR adds a helper method which uses Apache Commons IO FilenameUtils.concat function to build platform independent file paths

Github Issue: https://github.com/cqframework/cqf-tooling/issues/187
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
