### PR TITLE
Remove comments which are inconsistent with actual dictionary & remove unused entry

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/terminology/CodeSystemLookupDictionary.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/terminology/CodeSystemLookupDictionary.java
@@ -6,70 +6,6 @@ public class CodeSystemLookupDictionary {
 
     Using HL7's Terminology 1.0.0 Publication IG: http://terminology.hl7.org/codesystems.html
 
-    CodeSystem Name                 |  OID                                  | URL
-    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-        ActCode                     2.16.840.1.113883.5.4           ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html
-        ActMood                     2.16.840.1.113883.5.1001        ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html
-        ActPriority                 2.16.840.1.113883.5.7           ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-ActPriority.html
-        ActReason                   2.16.840.1.113883.5.8           ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-ActReason.html
-        ActRelationshipType         2.16.840.1.113883.5.1002        ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html
-        ActStatus                   2.16.840.1.113883.5.14          ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html
-        AddressUse                  2.16.840.1.113883.5.1119        ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-AddressUse.html
-        AdministrativeGender        2.16.840.1.113883.5.1           ->      http://terminology.hl7.org/1.0.0/CodeSystem-v3-AdministrativeGender.html
-        AdministrativeSex           2.16.840.1.113883.18.2          ->      http://terminology.hl7.org/1.0.0/CodeSystem-v2-0001.html
-        CPT                         2.16.840.1.113883.6.12          ->      http://terminology.hl7.org/CodeSystem-v3-cpt-4.html
-        CVX                         2.16.840.1.113883.12.292        ->      http://terminology.hl7.org/CodeSystem-v2-0292.html
-        Confidentiality             2.16.840.1.113883.5.25          ->      http://terminology.hl7.org/CodeSystem-v3-Confidentiality.html
-        DischargeDisposition        2.16.840.1.113883.12.112        ->      urn:oid:2.16.840.1.113883.12.112
-        DischargeDisposition        2.16.840.1.113883.4.642.1.1093  ->      http://terminology.hl7.org/CodeSystem-discharge-disposition.html
-        EntityNamePartQualifier     2.16.840.1.113883.5.43          ->      http://terminology.hl7.org/CodeSystem-v3-EntityNamePartQualifier.html
-        EntityNameUse               2.16.840.1.113883.5.45          ->      http://terminology.hl7.org/CodeSystem-v3-EntityNameUse.html
-        HCPCS                       2.16.840.1.113883.6.14          ->      http://terminology.hl7.org/CodeSystem-HCPCS.html
-        HCPCS Level I: CPT          2.16.840.1.113883.6.14          ->      http://terminology.hl7.org/CodeSystem-HCPCS.html
-        HCPCS Level II              2.16.840.1.113883.6.285         ->      https://terminology.hl7.org/CodeSystem-hcpcs-Level-II.html
-        HSLOC                       2.16.840.1.113883.6.259         ->      https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html
-        ICD10                       2.16.840.1.113883.6.3           ->      http://terminology.hl7.org/CodeSystem-icd10.html
-        ICD10PCS                    2.16.840.1.113883.6.4           ->      http://terminology.hl7.org/CodeSystem-icd10PCS.html
-        ICS10CM                     2.16.840.1.113883.6.90          ->      http://terminology.hl7.org/CodeSystem-icd10CM.html
-        ICD9                        2.16.840.1.113883.6.42          ->      http://terminology.hl7.org/CodeSystem-icd9.html
-        ICD9CM                      2.16.840.1.113883.6.2           ->      http://terminology.hl7.org/CodeSystem-icd9cm.html
-        ICD9PCS                     2.16.840.1.113883.6.104         ->      urn:oid:2.16.840.1.113883.6.104
-        LOINC                       2.16.840.1.113883.6.1           ->      http://terminology.hl7.org/NamingSystem-v3-loinc.html
-        LanguageAbilityMode         2.16.840.1.113883.5.60          ->      http://terminology.hl7.org/CodeSystem-v3-LanguageAbilityMode.html
-        LanguageAbilityProficiency  2.16.840.1.113883.5.61          ->      http://terminology.hl7.org/CodeSystem-v3-LanguageAbilityProficiency.html
-        LivingArrangement           2.16.840.1.113883.5.63          ->      http://terminology.hl7.org/CodeSystem-v3-LivingArrangement.html
-        MaritalStatus               2.16.840.1.113883.5.2           ->      http://terminology.hl7.org/CodeSystem-v3-MaritalStatus.html
-        NCI                         2.16.840.1.113883.3.26.1.1      ->      http://terminology.hl7.org/CodeSystem-v3-nciThesaurus.html
-        NDC                         2.16.840.1.113883.6.69          ->      https://terminology.hl7.org/CodeSystem-v3-ndc.html
-        NDFRT                       2.16.840.1.113883.3.26.1.5      ->      http://terminology.hl7.org/CodeSystem-nciVersionOfNDF-RT.html
-        NUCCPT                      2.16.840.1.113883.6.101         ->      http://terminology.hl7.org/CodeSystem-v3-nuccProviderCodes.html
-        PresentOnAdmission          2.16.840.1.113883.6.301.11      ->      https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/HospitalAcqCond/Coding
-        Provider Taxonomy           2.16.840.1.113883.6.101         ->      http://terminology.hl7.org/CodeSystem-v3-nuccProviderCodes.html
-        NullFlavor                  2.16.840.1.113883.5.1008        ->      http://terminology.hl7.org/CodeSystem-v3-NullFlavor.html
-        ObservationInterpretation   2.16.840.1.113883.5.83          ->      http://terminology.hl7.org/CodeSystem-v3-ObservationInterpretation.html
-        ObservationValue            2.16.840.1.113883.5.1063        ->      http://terminology.hl7.org/CodeSystem-v3-ObservationValue.html
-        ParticipationFunction       2.16.840.1.113883.5.88          ->      http://terminology.hl7.org/CodeSystem-v3-ParticipationFunction.html
-        ParticipationMode           2.16.840.1.113883.5.1064        ->      http://terminology.hl7.org/CodeSystem-v3-ParticipationMode.html
-        ParticipationType           2.16.840.1.113883.5.90          ->      http://terminology.hl7.org/CodeSystem-v3-ParticipationType.html
-        RXNORM                      2.16.840.1.113883.6.88          ->      http://terminology.hl7.org/NamingSystem-v3-rxNorm.html
-        ReligiousAffiliation        2.16.840.1.113883.5.1076        ->      http://terminology.hl7.org/CodeSystem-v3-ReligiousAffiliation.html
-        RoleClass                   2.16.840.1.113883.5.110         ->      http://terminology.hl7.org/CodeSystem-v3-RoleClass.html
-        RoleCode                    2.16.840.1.113883.5.111         ->      http://terminology.hl7.org/CodeSystem-v3-RoleCode.html
-        RoleStatus                  2.16.840.1.113883.5.1068        ->      http://terminology.hl7.org/CodeSystem-v3-RoleStatus.html
-        SNOMEDCT                    2.16.840.1.113883.6.96          ->      http://terminology.hl7.org/NamingSystem-v3-snomed-CT.html
-        UBREV                       2.16.840.1.113883.6.21          ->      http://terminology.hl7.org/CodeSystem-nubc-UB92.html
-        UBTOB                       2.16.840.1.113883.6.21          ->      http://terminology.hl7.org/CodeSystem-nubc-UB92.html
-        POS                         2.16.840.1.113883.6.50          ->      http://terminology.hl7.org/CodeSystem-POS.html
-        PYXIS                       ???                             ->      ???
-        CDCREC                      2.16.840.1.113883.6.238         ->      urn:oid:2.16.840.1.113883.6.238
-        CDT                         2.16.840.1.113883.6.13          ->      http://terminology.hl7.org/CodeSystem-CD2.html
-        mediaType                   2.16.840.1.113883.5.79          ->      http://terminology.hl7.org/CodeSystem-v3-mediatypes.html
-        SOP                         2.16.840.1.113883.3.221.5       ->      urn:oid:2.16.840.1.113883.3.221.5
-        UCUM                        1.3.6.1.4.1.12009.10.3.1        ->      urn:oid:1.3.6.1.4.1.12009.10.3.1
-        UCUM                        2.16.840.1.113883.6.8           ->      http://terminology.hl7.org/NamingSystem-v3-ucum.html
-        UMLS                        2.16.840.1.113883.6.86          ->      http://terminology.hl7.org/CodeSystem-umls.html
-
     */
 
     public static String getUrlFromOid(String oid) {
@@ -186,7 +122,6 @@ public class CodeSystemLookupDictionary {
             case "RoleCode": return "http://terminology.hl7.org/CodeSystem/v3-RoleCode";
             case "RoleStatus": return "http://terminology.hl7.org/CodeSystem/v3-RoleStatus";
             case "SNOMEDCT": return "http://snomed.info/sct";
-            case "SNOMED CT US Edition": return "http://snomed.info/sct";
             case "UBREV": return "http://terminology.hl7.org/CodeSystem/nubc-UB92";
             case "UBTOB": return "http://terminology.hl7.org/CodeSystem/nubc-UB92";
             case "POS": return "http://terminology.hl7.org/CodeSystem/POS";


### PR DESCRIPTION
**Description**

Removed comment table which is inconsistent with the actual mappings in the dictionary and as such is unhelpful to users.
Removed unused 'SNOMED CT US Edition' entry from the dictionary.

Github Issue: https://github.com/cqframework/cqf-tooling/issues/93 https://github.com/cqframework/cqf-tooling/issues/94
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
