### PR TITLE
Simple ordering of POST calls by resource type

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/common/ThreadUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/common/ThreadUtils.java
@@ -16,6 +16,8 @@ public class ThreadUtils {
 
     private static List<ExecutorService> runningExecutors = new ArrayList<>();
 
+    private static final int threadPoolCount = Runtime.getRuntime().availableProcessors() * 2;
+
     /**
      * Executes a list of tasks concurrently using a thread pool.
      * <p>
@@ -62,11 +64,15 @@ public class ThreadUtils {
     }
 
     public static void executeTasks(List<Callable<Void>> tasks) {
-        executeTasks(tasks, Executors.newCachedThreadPool());
+        ExecutorService executor = Executors.newFixedThreadPool(threadPoolCount);
+
+        executeTasks(tasks, executor);
     }
 
     public static void executeTasks(Queue<Callable<Void>> callables) {
-        executeTasks(new ArrayList<>(callables), Executors.newCachedThreadPool());
+        ExecutorService executor = Executors.newFixedThreadPool(threadPoolCount);
+
+        executeTasks(new ArrayList<>(callables), executor);
     }
 
     public static void shutdownRunningExecutors() {
@@ -77,7 +83,7 @@ public class ThreadUtils {
             }
             runningExecutors = new ArrayList<>();
         }catch (Exception e){
-            //fail silently, shutting down anyways
+            //fail silently, shutting down anyway
         }
     }
 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureBundler.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureBundler.java
@@ -70,7 +70,7 @@ public class MeasureBundler extends AbstractBundler {
             if (!(filesInDir == null || filesInDir.length == 0)) {
                 for (File file : filesInDir) {
 
-                    if (!file.getName().endsWith(".json") || !file.getName().endsWith(".xml")){
+                    if (!file.getName().toLowerCase().endsWith(".json") && !file.getName().toLowerCase().endsWith(".xml")){
                         continue;
                     }
 
@@ -81,7 +81,7 @@ public class MeasureBundler extends AbstractBundler {
                         persistedResources.add(file.getAbsolutePath());
                     } catch (Exception e) {
                         //resource is likely not IBaseResource
-                        logger.error("MeasureBundler.persistTestFilesWithPriority", e);
+                        logger.error("MeasureBundler.persistFilesFolder", e);
                     }
                 }
             }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureBundler.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureBundler.java
@@ -21,6 +21,7 @@ public class MeasureBundler extends AbstractBundler {
     public static String getId(String baseId) {
         return ResourcePrefix + baseId;
     }
+
     @Override
     protected String getSourcePath(FhirContext fhirContext, Map.Entry<String, IBaseResource> resourceEntry) {
         return IOUtils.getMeasurePathMap(fhirContext).get(resourceEntry.getKey());
@@ -44,14 +45,35 @@ public class MeasureBundler extends AbstractBundler {
     //so far only the Measure Bundle process needs to persist extra files:
     @Override
     protected int persistFilesFolder(String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri) {
-        //persist tests-* before group-* files and make a record of which files were tracked:
-        List<String> persistedFiles = persistTestFilesWithPriority(bundleDestPath, libraryName, encoding, fhirContext, fhirUri);
+        //files must be persisted in order, starting with valuesets:
+        List<String> persistedFiles = new ArrayList<>(persistFilesStartsWith("library-deps-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.LIBRARY_DEPS));
+        //library:
+        persistedFiles.addAll(persistFilesStartsWith("valuesets-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.VALUESETS));
+        //test bundles:
+        persistedFiles.addAll(persistFilesStartsWith("tests-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.TESTS));
+        //Group files:
+        persistedFiles.addAll(persistFilesStartsWith("Group-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.GROUP));
+        //everything else:
         persistedFiles.addAll(persistEverythingElse(bundleDestPath, libraryName, encoding, fhirContext, fhirUri, persistedFiles));
-
         return persistedFiles.size();
     }
 
-    private List<String> persistTestFilesWithPriority(String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri) {
+
+    /**
+     * This method will group files of similar naming to attempt to post the resources in an order that the fhir endpoint
+     * can understand. For instance, attempting to post a Group file before the Patient resource is posted can result
+     * in a reference error. To avoid running refresh twice, this ordering is necessary at POST.
+     *
+     * @param pattern
+     * @param bundleDestPath
+     * @param libraryName
+     * @param encoding
+     * @param fhirContext
+     * @param fhirUri
+     * @param rank
+     * @return
+     */
+    private List<String> persistFilesStartsWith(String pattern, String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri, HttpClientUtils.HttpPOSTResourceType rank) {
         List<String> persistedResources = new ArrayList<>();
         String filesLoc = bundleDestPath + File.separator + libraryName + "-files";
         File directory = new File(filesLoc);
@@ -59,10 +81,10 @@ public class MeasureBundler extends AbstractBundler {
             File[] filesInDir = directory.listFiles();
             if (!(filesInDir == null || filesInDir.length == 0)) {
                 for (File file : filesInDir) {
-                    if (file.getName().toLowerCase().startsWith("tests-")) {
+                    if (file.getName().toLowerCase().startsWith(pattern)) {
                         try {
                             IBaseResource resource = IOUtils.readResource(file.getAbsolutePath(), fhirContext, true);
-                            HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath(), true);
+                            HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath(), rank);
                             persistedResources.add(file.getAbsolutePath());
                         } catch (Exception e) {
                             //resource is likely not IBaseResource
@@ -75,6 +97,17 @@ public class MeasureBundler extends AbstractBundler {
         return persistedResources;
     }
 
+    /**
+     * Persists any files remaining after cycling through types to post in specific order
+     *
+     * @param bundleDestPath
+     * @param libraryName
+     * @param encoding
+     * @param fhirContext
+     * @param fhirUri
+     * @param alreadyPersisted
+     * @return
+     */
     private List<String> persistEverythingElse(String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri, List<String> alreadyPersisted) {
         List<String> persistedResources = new ArrayList<>();
         String filesLoc = bundleDestPath + File.separator + libraryName + "-files";
@@ -92,7 +125,7 @@ public class MeasureBundler extends AbstractBundler {
                     if (file.getName().toLowerCase().endsWith(".json") || file.getName().toLowerCase().endsWith(".xml")) {
                         try {
                             IBaseResource resource = IOUtils.readResource(file.getAbsolutePath(), fhirContext, true);
-                            HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath(), false);
+                            HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath());
                             persistedResources.add(file.getAbsolutePath());
                         } catch (Exception e) {
                             //resource is likely not IBaseResource

--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureBundler.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureBundler.java
@@ -16,6 +16,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public class MeasureBundler extends AbstractBundler {
     public static final String ResourcePrefix = "measure-";
+    public static final String LIBRARY_DEPS = "library-deps-";
+    public static final String VALUESETS = "valuesets-";
+    public static final String TESTS = "tests-";
+    public static final String GROUP = "group-";
+
     protected CopyOnWriteArrayList<Object> identifiers;
 
     public static String getId(String baseId) {
@@ -43,37 +48,20 @@ public class MeasureBundler extends AbstractBundler {
     }
 
     //so far only the Measure Bundle process needs to persist extra files:
-    @Override
-    protected int persistFilesFolder(String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri) {
-        //files must be persisted in order, starting with valuesets:
-        List<String> persistedFiles = new ArrayList<>(persistFilesStartsWith("library-deps-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.LIBRARY_DEPS));
-        //library:
-        persistedFiles.addAll(persistFilesStartsWith("valuesets-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.VALUESETS));
-        //test bundles:
-        persistedFiles.addAll(persistFilesStartsWith("tests-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.TESTS));
-        //Group files:
-        persistedFiles.addAll(persistFilesStartsWith("Group-", bundleDestPath, libraryName, encoding, fhirContext, fhirUri, HttpClientUtils.HttpPOSTResourceType.GROUP));
-        //everything else:
-        persistedFiles.addAll(persistEverythingElse(bundleDestPath, libraryName, encoding, fhirContext, fhirUri, persistedFiles));
-        return persistedFiles.size();
-    }
-
-
     /**
      * This method will group files of similar naming to attempt to post the resources in an order that the fhir endpoint
      * can understand. For instance, attempting to post a Group file before the Patient resource is posted can result
-     * in a reference error. To avoid running refresh twice, this ordering is necessary at POST.
+     * in a reference error.
      *
-     * @param pattern
      * @param bundleDestPath
      * @param libraryName
      * @param encoding
      * @param fhirContext
      * @param fhirUri
-     * @param rank
      * @return
      */
-    private List<String> persistFilesStartsWith(String pattern, String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri, HttpClientUtils.HttpPOSTResourceType rank) {
+    @Override
+    protected int persistFilesFolder(String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri) {
         List<String> persistedResources = new ArrayList<>();
         String filesLoc = bundleDestPath + File.separator + libraryName + "-files";
         File directory = new File(filesLoc);
@@ -81,60 +69,39 @@ public class MeasureBundler extends AbstractBundler {
             File[] filesInDir = directory.listFiles();
             if (!(filesInDir == null || filesInDir.length == 0)) {
                 for (File file : filesInDir) {
-                    if (file.getName().toLowerCase().startsWith(pattern)) {
-                        try {
-                            IBaseResource resource = IOUtils.readResource(file.getAbsolutePath(), fhirContext, true);
-                            HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath(), rank);
-                            persistedResources.add(file.getAbsolutePath());
-                        } catch (Exception e) {
-                            //resource is likely not IBaseResource
-                            logger.error("MeasureBundler.persistTestFilesWithPriority", e);
-                        }
-                    }
-                }
-            }
-        }
-        return persistedResources;
-    }
 
-    /**
-     * Persists any files remaining after cycling through types to post in specific order
-     *
-     * @param bundleDestPath
-     * @param libraryName
-     * @param encoding
-     * @param fhirContext
-     * @param fhirUri
-     * @param alreadyPersisted
-     * @return
-     */
-    private List<String> persistEverythingElse(String bundleDestPath, String libraryName, Encoding encoding, FhirContext fhirContext, String fhirUri, List<String> alreadyPersisted) {
-        List<String> persistedResources = new ArrayList<>();
-        String filesLoc = bundleDestPath + File.separator + libraryName + "-files";
-        File directory = new File(filesLoc);
-        if (directory.exists()) {
-
-            File[] filesInDir = directory.listFiles();
-
-            if (!(filesInDir == null || filesInDir.length == 0)) {
-                for (File file : filesInDir) {
-                    //don't post what has already been processed
-                    if (alreadyPersisted.contains(file.getAbsolutePath())) {
+                    if (!file.getName().endsWith(".json") || !file.getName().endsWith(".xml")){
                         continue;
                     }
-                    if (file.getName().toLowerCase().endsWith(".json") || file.getName().toLowerCase().endsWith(".xml")) {
-                        try {
-                            IBaseResource resource = IOUtils.readResource(file.getAbsolutePath(), fhirContext, true);
-                            HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath());
-                            persistedResources.add(file.getAbsolutePath());
-                        } catch (Exception e) {
-                            //resource is likely not IBaseResource
-                            logger.error("persistEverythingElse", e);
-                        }
+
+                    HttpClientUtils.HttpPOSTResourceType type = getHttpPOSTResourceType(file);
+                    try {
+                        IBaseResource resource = IOUtils.readResource(file.getAbsolutePath(), fhirContext, true);
+                        HttpClientUtils.post(fhirUri, resource, encoding, fhirContext, file.getAbsolutePath(), type);
+                        persistedResources.add(file.getAbsolutePath());
+                    } catch (Exception e) {
+                        //resource is likely not IBaseResource
+                        logger.error("MeasureBundler.persistTestFilesWithPriority", e);
                     }
                 }
             }
         }
-        return persistedResources;
+        return persistedResources.size();
     }
+
+    private static HttpClientUtils.HttpPOSTResourceType getHttpPOSTResourceType(File file) {
+        HttpClientUtils.HttpPOSTResourceType type = HttpClientUtils.HttpPOSTResourceType.OTHER;
+
+        if (file.getName().toLowerCase().startsWith(LIBRARY_DEPS)) {
+            type = HttpClientUtils.HttpPOSTResourceType.LIBRARY_DEPS;
+        } else if (file.getName().toLowerCase().startsWith(VALUESETS)) {
+            type = HttpClientUtils.HttpPOSTResourceType.VALUESETS;
+        } else if (file.getName().toLowerCase().startsWith(TESTS)) {
+            type = HttpClientUtils.HttpPOSTResourceType.TESTS;
+        } else if (file.getName().toLowerCase().startsWith(GROUP)) {
+            type = HttpClientUtils.HttpPOSTResourceType.GROUP;
+        }
+        return type;
+    }
+
 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/AbstractBundler.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/AbstractBundler.java
@@ -458,7 +458,8 @@ public abstract class AbstractBundler {
 
         if (fhirUri != null && !fhirUri.isEmpty()) {
             String resourceWriteLocation = bundleDestPath + separator + libraryName + "-bundle." + encoding;
-            HttpClientUtils.post(fhirUri, (IBaseResource) bundle, encoding, fhirContext, resourceWriteLocation, true);
+            //give resource the highest priority (0):
+            HttpClientUtils.post(fhirUri, (IBaseResource) bundle, encoding, fhirContext, resourceWriteLocation, HttpClientUtils.HttpPOSTResourceType.BUNDLE);
         }
     }
 
@@ -476,7 +477,7 @@ public abstract class AbstractBundler {
         IOUtils.copyFile(librarySourcePath, FilenameUtils.concat(bundleDestFilesPath, FilenameUtils.getName(librarySourcePath)));
 
         String cqlFileName = IOUtils.formatFileName(FilenameUtils.getBaseName(librarySourcePath), IOUtils.Encoding.CQL, fhirContext);
-        if (cqlFileName.toLowerCase().startsWith("library-")) {
+        if (cqlFileName.toLowerCase().startsWith("library-") && !cqlFileName.toLowerCase().startsWith("library-deps-")) {
             cqlFileName = cqlFileName.substring(8);
         }
         String cqlLibrarySourcePath = IOUtils.getCqlLibrarySourcePath(primaryLibraryName, cqlFileName, binaryPaths);

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/AbstractBundler.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/AbstractBundler.java
@@ -142,7 +142,7 @@ public abstract class AbstractBundler {
             final Map<String, String> libraryPathMap = new ConcurrentHashMap<>(IOUtils.getLibraryPathMap(fhirContext));
 
             if (resourcesMap.isEmpty()) {
-                logger.info("[INFO] No " + getResourceBundlerType() + "s found. Continuing...");
+                logger.info("\n\r" + "[INFO] No " + getResourceBundlerType() + "s found. Continuing...\n\r");
                 return;
             }
 
@@ -169,7 +169,7 @@ public abstract class AbstractBundler {
                 tasks.add(() -> {
                     //check if resourceSourcePath has been processed before:
                     if (processedResources.contains(resourceSourcePath)) {
-                        logger.info(getResourceBundlerType() + " processed already: " + resourceSourcePath);
+                        logger.info("\n\r" + getResourceBundlerType() + " processed already: " + resourceSourcePath);
                         return null;
                     }
                     String resourceName = FilenameUtils.getBaseName(resourceSourcePath).replace(getResourcePrefix(), "");
@@ -296,7 +296,7 @@ public abstract class AbstractBundler {
         //Output final report:
         String summaryOutput = generateBundleProcessSummary(refreshedLibraryNames, fhirContext, fhirUri, verboseMessaging,
                 persistedFileReport, bundledResources, failedExceptionMessages, cqlTranslatorErrorMessages).toString();
-        logger.info(summaryOutput);
+        logger.info("\n\r" + summaryOutput);
     }
 
     /**

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGBundleProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGBundleProcessor.java
@@ -49,7 +49,7 @@ public class IGBundleProcessor {
 
         //run collected post calls last:
         if (HttpClientUtils.hasPostTasksInQueue()) {
-            logger.info("[Persisting Files to " + fhirUri + "]");
+            logger.info("\n\r[Persisting Files to " + fhirUri + "]\n\r");
             HttpClientUtils.postTaskCollection();
         }
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
@@ -52,7 +52,6 @@ public class HttpClientUtils {
     //failedPostCalls needs to maintain the details built in the FAILED message, as well as a copy of the inputs for a retry by the user on failed posts.
     private static Queue<Pair<String, PostComponent>> failedPostCalls = new ConcurrentLinkedQueue<>();
     private static List<String> successfulPostCalls = new CopyOnWriteArrayList<>();
-//    private static Map<IBaseResource, Callable<Void>> tasks = new ConcurrentHashMap<>();
 
     //Parent map uses resourceType as key so that resourceTypes can have their tasks called in a specific order:
     private static ConcurrentHashMap<HttpPOSTResourceType, ConcurrentHashMap<IBaseResource, Callable<Void>>> mappedTasksByPriorityRank = new ConcurrentHashMap<>();

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
@@ -71,13 +71,9 @@ public class HttpClientUtils {
         OTHER("Everything Else");
 
         private final String displayName;
-
-        // Constructor to initialize the enum with a string value
         HttpPOSTResourceType(String displayName) {
             this.displayName = displayName;
         }
-
-        // Method to get the associated string value
         public String getDisplayName() {
             return displayName;
         }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
@@ -70,9 +70,11 @@ public class HttpClientUtils {
         OTHER("Everything Else");
 
         private final String displayName;
+
         HttpPOSTResourceType(String displayName) {
             this.displayName = displayName;
         }
+
         public String getDisplayName() {
             return displayName;
         }
@@ -352,7 +354,7 @@ public class HttpClientUtils {
 
         for (int i = 0; i < resourceTypePostOrder.size(); i++) {
             HttpPOSTResourceType iterType = resourceTypePostOrder.get(i);
-            if (iterType == postType){
+            if (iterType == postType) {
                 break;
             }
             if (mappedTasksByPriorityRank.containsKey(iterType)) {
@@ -399,7 +401,7 @@ public class HttpClientUtils {
     }
 
 
-    private static void reportProgress(){
+    private static void reportProgress() {
         reportProgress(null);
     }
 
@@ -409,6 +411,21 @@ public class HttpClientUtils {
             totalCount += map.size();
         }
         return totalCount;
+    }
+
+    private static String getPresentTypesAndCounts() {
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < resourceTypePostOrder.size(); i++) {
+            //execute the tasks in order specified
+            if (mappedTasksByPriorityRank.containsKey(resourceTypePostOrder.get(i))) {
+                output.append("\n\r - ")
+                        .append(resourceTypePostOrder.get(i).displayName)
+                        .append(": ")
+                        .append(mappedTasksByPriorityRank.get(resourceTypePostOrder.get(i)).size());
+            }
+        }
+
+        return output.toString();
     }
 
     /**
@@ -429,11 +446,15 @@ public class HttpClientUtils {
         ExecutorService executorService = Executors.newFixedThreadPool(1);
 
         try {
-            logger.info("\n\r" + getTotalTaskCount() + " POST calls to be made. Starting now. Please wait..." + "\n\r");
+            logger.info("\n\r" + getTotalTaskCount() +
+                    " POST calls to be made: " +
+                    getPresentTypesAndCounts() +
+                    "\n\r Executing, please wait..." + "\n\r");
+
             runPostCalls(executorService);
 
 
-            logger.info("\n\r" + "Processing results..."+ "\n\r");
+            logger.info("\n\r" + "Processing results..." + "\n\r");
             Collections.sort(successfulPostCalls);
 
             StringBuilder message = new StringBuilder();
@@ -513,6 +534,7 @@ public class HttpClientUtils {
 
     /**
      * Executes the tasks for each priority ranking, sorted:
+     *
      * @param executorService
      */
     private static void runPostCalls(ExecutorService executorService) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
@@ -342,7 +342,7 @@ public class HttpClientUtils {
         }
     }
 
-    private static String getSectionPercentage(HttpPOSTResourceType postType) {
+    private static String getSectionProgress(HttpPOSTResourceType postType) {
         //processedPostCounter holds the count we're at.
         //logically all preceding items up until this point are processed
         //add all sections until we get to this type, subtract total processed from other type count
@@ -365,7 +365,7 @@ public class HttpClientUtils {
 
         double percentage = (double) currentCounter / thisTypeProcessedCount * 100;
 
-        return String.format("%.2f%%", percentage);
+        return currentCounter + "/" + thisTypeProcessedCount + " (" + String.format("%.2f%%", percentage) + ")";
     }
 
     /**
@@ -380,13 +380,16 @@ public class HttpClientUtils {
 
         String fileGroup = "";
         if (postType != null) {
-            fileGroup = "Posting: " + postType.getDisplayName() + " (" + getSectionPercentage(postType) + ")";
+            fileGroup = " | Posting: " + postType.getDisplayName() + " " + getSectionProgress(postType);
         }
 
-        double percentage = (double) currentCounter / getTotalTaskCount() * 100;
-        String progressStr = "\rOverall Progress: " + String.format("%.2f%%", percentage) + ". " +
-                "POST response pool size: " + runningPostTaskList.size() + ". " +
-                fileGroup;
+        int taskCount = getTotalTaskCount();
+        double percentage = (double) currentCounter / taskCount * 100;
+        String percentOutput = String.format("%.2f%%", percentage);
+
+        String progressStr = "\rProgress: " + percentOutput + " (" + currentCounter + "/" + taskCount + ")" +
+                fileGroup +
+                " | Response pool: " + runningPostTaskList.size() + "";
 
 
         String repeatedString = " ".repeat(progressStr.length() * 2);

--- a/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/utilities/HttpClientUtils.java
@@ -84,7 +84,7 @@ public class HttpClientUtils {
     }
 
     //POST in order: Bundle, Library-Deps, ValueSets, Tests, Group
-    private static List<HttpPOSTResourceType> resourceTypePostOrder = new ArrayList<>(Arrays.asList(
+    private static final List<HttpPOSTResourceType> resourceTypePostOrder = new ArrayList<>(Arrays.asList(
             HttpPOSTResourceType.BUNDLE,
             HttpPOSTResourceType.LIBRARY_DEPS,
             HttpPOSTResourceType.VALUESETS,
@@ -109,9 +109,8 @@ public class HttpClientUtils {
      * @param encoding      The encoding type of the resource.
      * @param fhirContext   The FHIR context for the resource.
      * @param fileLocation  Optional fileLocation indicator for identifying resources by raw filename
-     * @param priorityRank  A key in our mappedTasksByPriorityRank. Allows specification of the priority order in which
-     *                      this POST operation should occur, for example: Bundle, Library dependencies, value sets,
-     *                      tests, group files, then other resources...
+     * @param priorityRank  A key in our mappedTasksByPriorityRank using HttpPOSTResourceType. Allows specification of
+     *                      the resource type for priority ordering at execute.
      * @throws IOException If an I/O error occurs during the request.
      */
     public static void post(String fhirServerUrl, IBaseResource resource, IOUtils.Encoding encoding, FhirContext fhirContext, String fileLocation, HttpPOSTResourceType priorityRank) throws IOException {


### PR DESCRIPTION
When running Refresh and specifying a FHIR server to persist the resources to, I found resources that would fail in the initial attempt, but POST in the second attempt, indicating a dependency on some other resource to POST first. I've identified an order for these resources to be posted in: Bundle, Library Dependencies, Value Sets, Tests, and Patient Group files. With this grouping of resources and creating an order in which they are sent to the server, the initial attempt at posting the resources is far more successful and consistent. 

When calling HttpClientUtils.post, the enum HttpPOSTResourceType can be specified. When executing the tasks, HttpClientUtils.resourceTypePostOrder is used to execute each group of tasks in the order specified. 


- [X] I've read the contribution guidelines 
- [X] Code compiles without errors
- [X] Tests are created / updated
- [X] Documentation is created / updated

