### PR TITLE
Added support for population-level data requirement processing to IG refresh measure processor

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/MeasureProcessor.java
@@ -20,23 +20,25 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class MeasureProcessor extends BaseProcessor {
-    public static String ResourcePrefix = "measure-";
+    public static final String RESOURCE_PREFIX = "measure-";
     protected List<Object> identifiers;
 
     public static String getId(String baseId) {
-        return ResourcePrefix + baseId;
+        return RESOURCE_PREFIX + baseId;
     }
 
     public List<String> refreshIgMeasureContent(BaseProcessor parentContext, Encoding outputEncoding, Boolean versioned, FhirContext fhirContext,
-                                                String measureToRefreshPath, Boolean shouldApplySoftwareSystemStamp) {
+                                                String measureToRefreshPath, Boolean shouldApplySoftwareSystemStamp, Boolean shouldIncludePopDataRequirements) {
 
         return refreshIgMeasureContent(parentContext, outputEncoding, null, versioned, fhirContext, measureToRefreshPath,
-                shouldApplySoftwareSystemStamp);
+                shouldApplySoftwareSystemStamp, shouldIncludePopDataRequirements);
     }
+
+
 
     public List<String> refreshIgMeasureContent(BaseProcessor parentContext, Encoding outputEncoding, String measureOutputDirectory,
                                                 Boolean versioned, FhirContext fhirContext, String measureToRefreshPath,
-                                                Boolean shouldApplySoftwareSystemStamp) {
+                                                Boolean shouldApplySoftwareSystemStamp, Boolean shouldIncludePopDataRequirements) {
 
         logger.info("[Refreshing Measures]");
 
@@ -61,6 +63,8 @@ public class MeasureProcessor extends BaseProcessor {
         params.encoding = outputEncoding;
         params.versioned = versioned;
         params.measureOutputDirectory = measureOutputDirectory;
+        params.shouldApplySoftwareSystemStamp = shouldApplySoftwareSystemStamp;
+        params.includePopulationDataRequirements = shouldIncludePopDataRequirements;
         List<String> contentList = measureProcessor.refreshMeasureContent(params);
 
         if (!measureProcessor.getIdentifiers().isEmpty()) {
@@ -111,7 +115,7 @@ public class MeasureProcessor extends BaseProcessor {
         VersionedIdentifier primaryLibraryIdentifier = CanonicalUtils.toVersionedIdentifier(libraryUrl);
 
         List<CqlCompilerException> errors = new CopyOnWriteArrayList<>();
-        CompiledLibrary CompiledLibrary = libraryManager.resolveLibrary(primaryLibraryIdentifier, errors);
+        CompiledLibrary compiledLibrary = libraryManager.resolveLibrary(primaryLibraryIdentifier, errors);
 
         logger.info(CqlProcessor.buildStatusMessage(errors, measure.getName(), verboseMessaging));
 
@@ -119,7 +123,7 @@ public class MeasureProcessor extends BaseProcessor {
 
         //refresh measures without severe errors:
         if (!hasSevereErrors) {
-            return processor.refreshMeasure(measure, libraryManager, CompiledLibrary, cqlTranslatorOptions.getCqlCompilerOptions());
+            return processor.refreshMeasure(measure, libraryManager, compiledLibrary, cqlTranslatorOptions.getCqlCompilerOptions());
         }
 
         return measure;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/measure/r4/R4MeasureProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/measure/r4/R4MeasureProcessor.java
@@ -1,21 +1,34 @@
 package org.opencds.cqf.tooling.measure.r4;
 
+import org.cqframework.cql.cql2elm.CqlCompilerException;
+import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
+import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
 import org.hl7.fhir.convertors.conv40_50.VersionConvertor_40_50;
 import org.hl7.fhir.r4.formats.FormatUtilities;
+import org.hl7.fhir.r5.model.Measure;
 import org.opencds.cqf.tooling.common.r4.CqfmSoftwareSystemHelper;
 import org.opencds.cqf.tooling.measure.MeasureProcessor;
+import org.opencds.cqf.tooling.measure.MeasureRefreshProcessor;
 import org.opencds.cqf.tooling.parameter.RefreshMeasureParameters;
+import org.opencds.cqf.tooling.processor.CqlProcessor;
+import org.opencds.cqf.tooling.utilities.CanonicalUtils;
 import org.opencds.cqf.tooling.utilities.IOUtils;
+import org.opencds.cqf.tooling.utilities.ResourceUtils;
 
 import java.io.File;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class R4MeasureProcessor extends MeasureProcessor {
 
     private String measurePath;
     private String measureOutputDirectory;
     private IOUtils.Encoding encoding;
+    private Boolean shouldApplySoftwareSystemStamp;
+    private Boolean includePopulationDataRequirements;
     private static CqfmSoftwareSystemHelper cqfmHelper;
 
     private String getMeasurePath(String measurePath) {
@@ -60,11 +73,11 @@ public class R4MeasureProcessor extends MeasureProcessor {
             loadMeasure(fileMap, measures, file);
         }
 
-        List<String> refreshedMeasureNames = new ArrayList<String>();
-        List<org.hl7.fhir.r5.model.Measure> refreshedMeasures = super.refreshGeneratedContent(measures);
-        VersionConvertor_40_50 versionConvertor_40_50 = new VersionConvertor_40_50(new BaseAdvisor_40_50());
+        List<String> refreshedMeasureNames = new ArrayList<>();
+        List<org.hl7.fhir.r5.model.Measure> refreshedMeasures = refreshGeneratedContent(measures);
+        VersionConvertor_40_50 versionConvertor = new VersionConvertor_40_50(new BaseAdvisor_40_50());
         for (org.hl7.fhir.r5.model.Measure refreshedMeasure : refreshedMeasures) {
-            org.hl7.fhir.r4.model.Measure measure = (org.hl7.fhir.r4.model.Measure) versionConvertor_40_50.convertResource(refreshedMeasure);
+            org.hl7.fhir.r4.model.Measure measure = (org.hl7.fhir.r4.model.Measure) versionConvertor.convertResource(refreshedMeasure);
             if (measure.hasIdentifier() && !measure.getIdentifier().isEmpty()) {
                 this.getIdentifiers().addAll(measure.getIdentifier());
             }
@@ -111,13 +124,59 @@ public class R4MeasureProcessor extends MeasureProcessor {
     private void loadMeasure(Map<String, String> fileMap, List<org.hl7.fhir.r5.model.Measure> measures, File measureFile) {
         try {
             org.hl7.fhir.r4.model.Resource resource = FormatUtilities.loadFile(measureFile.getAbsolutePath());
-            VersionConvertor_40_50 versionConvertor_40_50 = new VersionConvertor_40_50(new BaseAdvisor_40_50());
-            org.hl7.fhir.r5.model.Measure measure = (org.hl7.fhir.r5.model.Measure) versionConvertor_40_50.convertResource(resource);
+            VersionConvertor_40_50 versionConvertor = new VersionConvertor_40_50(new BaseAdvisor_40_50());
+            org.hl7.fhir.r5.model.Measure measure = (org.hl7.fhir.r5.model.Measure) versionConvertor.convertResource(resource);
             fileMap.put(measure.getId(), measureFile.getAbsolutePath());
             measures.add(measure);
         } catch (Exception ex) {
             logMessage(String.format("Error reading measure: %s. Error: %s", measureFile.getAbsolutePath(), ex.getMessage()));
         }
+    }
+
+    @Override
+    protected List<Measure> refreshGeneratedContent(List<Measure> sourceMeasures) {
+        return internalRefreshGeneratedContent(sourceMeasures);
+    }
+
+    private List<Measure> internalRefreshGeneratedContent(List<Measure> sourceMeasures) {
+        // for each Measure, refresh the measure based on the primary measure library
+        List<Measure> resources = new ArrayList<>();
+        MeasureRefreshProcessor processor = new MeasureRefreshProcessor();
+        LibraryManager libraryManager = getCqlProcessor().getLibraryManager();
+        CqlTranslatorOptions cqlTranslatorOptions = getCqlProcessor().getCqlTranslatorOptions();
+        for (Measure measure : sourceMeasures) {
+            // Do not attempt to refresh if the measure does not have a library
+            if (measure.hasLibrary()) {
+                resources.add(refreshGeneratedContent(measure, processor, libraryManager, cqlTranslatorOptions));
+            } else {
+                resources.add(measure);
+            }
+        }
+
+        return resources;
+    }
+
+    private Measure refreshGeneratedContent(Measure measure, MeasureRefreshProcessor processor, LibraryManager libraryManager, CqlTranslatorOptions cqlTranslatorOptions) {
+
+        String libraryUrl = ResourceUtils.getPrimaryLibraryUrl(measure, fhirContext);
+        VersionedIdentifier primaryLibraryIdentifier = CanonicalUtils.toVersionedIdentifier(libraryUrl);
+
+        List<CqlCompilerException> errors = new CopyOnWriteArrayList<>();
+        CompiledLibrary compiledLibrary = libraryManager.resolveLibrary(primaryLibraryIdentifier, errors);
+
+        logger.info(CqlProcessor.buildStatusMessage(errors, measure.getName(), verboseMessaging));
+
+        boolean hasSevereErrors = CqlProcessor.hasSevereErrors(errors);
+
+        //refresh measures without severe errors:
+        if (!hasSevereErrors) {
+            if (includePopulationDataRequirements != null) {
+                processor.includePopulationDataRequirements = includePopulationDataRequirements;
+            }
+            return processor.refreshMeasure(measure, libraryManager, compiledLibrary, cqlTranslatorOptions.getCqlCompilerOptions());
+        }
+
+        return measure;
     }
 
     @Override
@@ -134,6 +193,8 @@ public class R4MeasureProcessor extends MeasureProcessor {
         fhirContext = params.fhirContext;
         encoding = params.encoding;
         versioned = params.versioned;
+        shouldApplySoftwareSystemStamp = params.shouldApplySoftwareSystemStamp;
+        includePopulationDataRequirements = params.includePopulationDataRequirements;
 
         R4MeasureProcessor.cqfmHelper = new CqfmSoftwareSystemHelper(rootDir);
 

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/RefreshGeneratedContentOperation.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/RefreshGeneratedContentOperation.java
@@ -13,7 +13,7 @@ public abstract class RefreshGeneratedContentOperation extends Operation {
     protected FhirContext fhirContext;
     private String pathToMeasures; // -ptm
     private String pathToLibraries; // -ptl
-    private String operationName;
+    private final String operationName;
 
     protected Boolean shouldApplySoftwareSystemStamp; // -ss
     protected Boolean addBundleTimestamp; // -ts

--- a/tooling/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/parameter/RefreshIGParameters.java
@@ -26,4 +26,5 @@ public class RefreshIGParameters {
     public String measureOutputPath;
     public Boolean verboseMessaging;
     public String updatedVersion;
+    public Boolean includePopulationLevelDataRequirements;
 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/parameter/RefreshMeasureParameters.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/parameter/RefreshMeasureParameters.java
@@ -32,7 +32,7 @@ public class RefreshMeasureParameters {
     public Encoding encoding;
 
     /*
-    Whether or not version is included in the name
+    Whether the version is included in the name
      */
     public Boolean versioned;
 
@@ -52,4 +52,8 @@ public class RefreshMeasureParameters {
     public String measureOutputDirectory;
 
     public Boolean verboseMessaging;
+
+    public Boolean shouldApplySoftwareSystemStamp;
+
+    public Boolean includePopulationDataRequirements;
 }

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/IGProcessor.java
@@ -146,7 +146,6 @@ public class IGProcessor extends BaseProcessor {
         Boolean includePatientScenarios = params.includePatientScenarios;
         Boolean versioned = params.versioned;
 
-
         IOUtils.resourceDirectories.addAll(resourceDirs);
         FhirContext fhirContext = IGProcessor.getIgFhirContext(fhirVersion);
         IGProcessor.ensure(rootDir, includePatientScenarios, params.includeTerminology, IOUtils.resourceDirectories);
@@ -157,10 +156,10 @@ public class IGProcessor extends BaseProcessor {
 
         if (Strings.isNullOrEmpty(measureOutputPath)) {
             refreshedResourcesNames.addAll(new MeasureProcessor().refreshIgMeasureContent(this, encoding, versioned,
-                    fhirContext, measureToRefreshPath, params.shouldApplySoftwareSystemStamp));
+                    fhirContext, measureToRefreshPath, params.shouldApplySoftwareSystemStamp, params.includePopulationLevelDataRequirements));
         } else {
             refreshedResourcesNames.addAll(new MeasureProcessor().refreshIgMeasureContent(this, encoding, measureOutputPath,
-                    versioned, fhirContext, measureToRefreshPath, params.shouldApplySoftwareSystemStamp));
+                    versioned, fhirContext, measureToRefreshPath, params.shouldApplySoftwareSystemStamp, params.includePopulationLevelDataRequirements));
         }
 
         if (refreshedResourcesNames.isEmpty()) {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/argument/RefreshIGArgumentProcessor.java
@@ -38,6 +38,7 @@ public class RefreshIGArgumentProcessor {
     public static final String[] SHOULD_APPLY_SOFTWARE_SYSTEM_STAMP_OPTIONS = { "ss", "stamp" };
     public static final String[] SHOULD_ADD_TIMESTAMP_OPTIONS = { "ts", "timestamp" };
     public static final String[] SHOULD_INCLUDE_ERRORS = { "x", "include-errors" };
+    public static final String[] INCLUDE_POP_LEVEL_DATA_REQUIREMENTS_OPTIONS = { "pldr", "popDataRequirements" };
 
 
     @SuppressWarnings("unused")
@@ -85,6 +86,7 @@ public class RefreshIGArgumentProcessor {
         parser.acceptsAll(asList(INCLUDE_PATIENT_SCENARIOS_OPTIONS),"If omitted patient scenario information will not be packaged.");
         parser.acceptsAll(asList(VERSIONED_OPTIONS),"If omitted resources must be uniquely named.");
         parser.acceptsAll(asList(SHOULD_INCLUDE_ERRORS),"Specifies whether to show errors during library, measure, and test case refresh.");
+        parser.acceptsAll(asList(INCLUDE_POP_LEVEL_DATA_REQUIREMENTS_OPTIONS), "If omitted, the measures will not include population-level data requirements");
 
         OptionSpec<Void> help = parser.acceptsAll(asList(ArgUtils.HELP_OPTIONS), "Show this help page").forHelp();
 
@@ -118,12 +120,13 @@ public class RefreshIGArgumentProcessor {
         if (igEncoding != null) {
             outputEncodingEnum = Encoding.parse(igEncoding.toLowerCase());
         }
-        Boolean skipPackages = options.has(SKIP_PACKAGES_OPTIONS[0]);
-        Boolean includeELM = options.has(INCLUDE_ELM_OPTIONS[0]);
-        Boolean includeDependencies = options.has(INCLUDE_DEPENDENCY_LIBRARY_OPTIONS[0]);
-        Boolean includeTerminology = options.has(INCLUDE_TERMINOLOGY_OPTIONS[0]);
-        Boolean includePatientScenarios = options.has(INCLUDE_PATIENT_SCENARIOS_OPTIONS[0]);
-        Boolean versioned = options.has(VERSIONED_OPTIONS[0]);
+        boolean skipPackages = options.has(SKIP_PACKAGES_OPTIONS[0]);
+        boolean includeELM = options.has(INCLUDE_ELM_OPTIONS[0]);
+        boolean includeDependencies = options.has(INCLUDE_DEPENDENCY_LIBRARY_OPTIONS[0]);
+        boolean includeTerminology = options.has(INCLUDE_TERMINOLOGY_OPTIONS[0]);
+        boolean includePatientScenarios = options.has(INCLUDE_PATIENT_SCENARIOS_OPTIONS[0]);
+        boolean versioned = options.has(VERSIONED_OPTIONS[0]);
+        boolean includePopLevelDataRequirements = options.has(INCLUDE_POP_LEVEL_DATA_REQUIREMENTS_OPTIONS[0]);
         String fhirUri = (String)options.valueOf(FHIR_URI_OPTIONS[0]);
         String measureToRefreshPath = (String)options.valueOf(MEASURE_TO_REFRESH_PATH[0]);
 
@@ -156,7 +159,7 @@ public class RefreshIGArgumentProcessor {
             addBundleTimestamp = true;
         }
 
-        Boolean verboseMessaging = options.has(SHOULD_INCLUDE_ERRORS[0]);
+        boolean verboseMessaging = options.has(SHOULD_INCLUDE_ERRORS[0]);
 
         ArrayList<String> paths = new ArrayList<String>();
         if (resourcePaths != null && !resourcePaths.isEmpty()) {
@@ -188,6 +191,7 @@ public class RefreshIGArgumentProcessor {
         ip.measureOutputPath = measureOutputPath;
         ip.updatedVersion = updatedVersion;
         ip.verboseMessaging = verboseMessaging;
+        ip.includePopulationLevelDataRequirements = includePopLevelDataRequirements;
         return ip;
     }
 }


### PR DESCRIPTION
<!-- give your PR a concise title describing the feature above -->

**Description**

This PR contains the necessary updates to support Measure population-level data requirement processing for the IG refresh operation. The outcome of this update will include contained module definition libraries for each of the Measure.group.population defined in the measure if the appropriate flag is present when invoking the IG refresh operation.

<!-- add a brief description of the changes here -->

- Updated Refresh IG params to include flag for population level data requirement processing
- Added the population level data requirement processing logic to the MeasureRefreshProcessor
- Tested locally with the NHSN measure repository measures

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [ ] Tests are created / updated
- [ ] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
