### PR TITLE
Support transitive dependencies

### DIFF
--- a/tooling/src/main/java/org/opencds/cqf/tooling/npm/NpmPackageManager.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/npm/NpmPackageManager.java
@@ -226,10 +226,7 @@ public class NpmPackageManager {
 
     private NpmPackage loadPackageSafely(String id, String version) {
         try {
-            //if (!pcm.packageExists(id, version)) {
-                return pcm.loadPackage(id, version);
-            //}
-            //return null;
+            return pcm.loadPackage(id, version);
         } catch (IOException e) {
             logger.warn("Dependency {}#{} not found by FilesystemPackageCacheManager", id, version);
             return null;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/npm/NpmPackageManager.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/npm/NpmPackageManager.java
@@ -180,6 +180,21 @@ public class NpmPackageManager {
                 logger.warn("The correct canonical URL for this dependency is " + cu);
             }
         }
+
+        if (!pi.dependencies().isEmpty()) {
+            for (String dependency : pi.dependencies()) {
+                String[] idAndVersion = dependency.split("#");
+                NpmPackage pid = pcm.loadPackage(idAndVersion[0], idAndVersion[1]);
+                if (pid == null) {
+                    logger.warn("Dependency " + idAndVersion[0] + "not found by FilesystemPackageCacheManager");
+                }
+                npmList.add(pid);
+
+                logger.debug(
+                        "Load " + name + " (" + canonical + ") from " + packageId + "#" + igver);
+
+            }
+        }
     }
 
     private String determineCanonical(String url, String path) throws FHIRException {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/ig/LibraryRefresh.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/ig/LibraryRefresh.java
@@ -47,7 +47,7 @@ public class LibraryRefresh extends Refresh {
       List<NpmPackage> packageList = cleanPackageList(this.npmPackageManager.getNpmList());
       this.cqlProcessor = new CqlProcessor(packageList,
               Collections.singletonList(igInfo.getCqlBinaryPath()), libraryLoader, new IGLoggingService(logger), ucumService,
-              igInfo.getPackageId(), igInfo.getCanonical(), true);
+              igInfo.getIgResource(), getFhirContext().getVersion().toString(),true);
    }
    @Override
    public List<IBaseResource> refresh() {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/operation/ig/LibraryRefresh.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/operation/ig/LibraryRefresh.java
@@ -35,8 +35,9 @@ public class LibraryRefresh extends Refresh {
 
    public LibraryRefresh(IGInfo igInfo) {
       super(igInfo);
-       this.npmPackageManager = new NpmPackageManager(igInfo.getIgResource(), igInfo.getFhirContext().getVersion().getVersion().getFhirVersionString() );
-       this.libraryPackages = new ArrayList<>();
+
+      this.npmPackageManager = new NpmPackageManager(igInfo.getIgResource(), igInfo.getFhirContext().getVersion().getVersion().getFhirVersionString() );
+      this.libraryPackages = new ArrayList<>();
       LibraryLoader libraryLoader = new LibraryLoader(igInfo.getFhirContext().getVersion().getVersion().getFhirVersionString());
       UcumEssenceService ucumService;
       try {
@@ -46,8 +47,13 @@ public class LibraryRefresh extends Refresh {
       }
       List<NpmPackage> packageList = cleanPackageList(this.npmPackageManager.getNpmList());
       this.cqlProcessor = new CqlProcessor(packageList,
-              Collections.singletonList(igInfo.getCqlBinaryPath()), libraryLoader, new IGLoggingService(logger), ucumService,
-              igInfo.getIgResource(), getFhirContext().getVersion().toString(),true);
+              Collections.singletonList(igInfo.getCqlBinaryPath()),
+              libraryLoader,
+              new IGLoggingService(logger),
+              ucumService,
+              igInfo.getIgResource(),
+              igInfo.getFhirContext().getVersion().getVersion().getFhirVersionString(),
+              true);
    }
    @Override
    public List<IBaseResource> refresh() {

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/BaseProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/BaseProcessor.java
@@ -169,7 +169,7 @@ public class BaseProcessor implements IProcessorContext, IWorkerContext.ILogging
             }
             cqlProcessor = new CqlProcessor(new CopyOnWriteArrayList<>(packageManager.getNpmList()),
                     new CopyOnWriteArrayList<>(binaryPaths), reader, this, ucumService,
-                    packageId, canonicalBase, verboseMessaging);
+                    sourceIg, getFhirVersion(), verboseMessaging);
         }
 
         return cqlProcessor;

--- a/tooling/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
+++ b/tooling/src/main/java/org/opencds/cqf/tooling/processor/CqlProcessor.java
@@ -163,17 +163,23 @@ public class CqlProcessor {
 
     private NamespaceInfo namespaceInfo;
 
+    private ImplementationGuide sourceIg;
+
+    private String fhirVersion;
+
     private boolean verboseMessaging;
 
-    public CqlProcessor(List<NpmPackage> packages, List<String> folders, ILibraryReader reader, ILoggingService logger, UcumService ucumService, String packageId, String canonicalBase, Boolean verboseMessaging) {
+    public CqlProcessor(List<NpmPackage> packages, List<String> folders, ILibraryReader reader, ILoggingService logger, UcumService ucumService, ImplementationGuide sourceIg, String fhirVersion, Boolean verboseMessaging) {
         super();
         this.packages = packages;
         this.folders = folders;
         this.reader = reader;
         this.logger = logger;
         this.ucumService = ucumService;
-        this.packageId = packageId;
-        this.canonicalBase = canonicalBase;
+        this.sourceIg = sourceIg;
+        this.packageId = sourceIg.getId();
+        this.canonicalBase = sourceIg.getUrl();
+        this.fhirVersion = fhirVersion;
         if (packageId != null && !packageId.isEmpty() && canonicalBase != null && !canonicalBase.isEmpty()) {
             this.namespaceInfo = new NamespaceInfo(packageId, canonicalBase);
         }


### PR DESCRIPTION
Support for transitive dependencies

**Description**

Allows transitive dependencies (FHIR packages) to be loaded. This is in support of CQL namespaces. Works with https://github.com/reason-healthcare/crmi-reusable-cql