### PR TITLE
Revert inadvertently-changed maven compiler plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.12.0-SNAPSHOT</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <failOnWarning>true</failOnWarning>
                         <showWarnings>true</showWarnings>


### PR DESCRIPTION
The maven compiler plugin version was incorrectly changed in a previous commit. This reverts that change.

- Github Issue:  <!-- link the relevant GitHub issue here -->
- [x] I've read the contribution guidelines <!-- use - [x] to mark the item as complete -->
- [x] Code compiles without errors
- [x] Tests are created / updated
- [x] Documentation is created / updated

By creating this PR you acknowledge that your contribution will be licensed under Apache 2.0
